### PR TITLE
Log failures to load the native library

### DIFF
--- a/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
+++ b/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.aesgcmsiv;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.crypto.AEADBadTagException;
 
 public final class AESGCMSIV {
@@ -32,6 +35,7 @@ public final class AESGCMSIV {
         try {
             ResourceLoader.loadLibraryFromJar("aesgcmsiv_jni");
         } catch (Exception e) {
+            Logger.getLogger("AESGCMSIV").log(Level.SEVERE, "Failed to load aesgcmsiv_jni", e);
         }
     }
 

--- a/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
+++ b/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
@@ -56,7 +56,8 @@ public final class AESGCMSIV {
         init(key);
     }
 
-    public void finalize() {
+    @Override
+    protected void finalize() {
         free();
     }
 

--- a/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/ResourceLoader.java
+++ b/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/ResourceLoader.java
@@ -26,10 +26,10 @@ import java.nio.file.StandardCopyOption;
 import java.util.Random;
 
 final class ResourceLoader {
-    private final static String TMP_DIR_PREFIX = "aesgcmsiv_jni";
-    private final static String JNI_BASE_DIR = "jni/";
-    private static File tmpDir = null;
-    private static File archDir = null;
+    private static final String TMP_DIR_PREFIX = "aesgcmsiv_jni";
+    private static final String JNI_BASE_DIR = "jni/";
+    private static File tmpDir;
+    private static File archDir;
 
     public static void loadLibraryFromJar(String name) throws IOException {
         File tmpLib = extractJarResource(name);
@@ -58,55 +58,55 @@ final class ResourceLoader {
         return tmpFile;
     }
 
-    private synchronized static File getTmpDirectory() throws IOException {
-        if (ResourceLoader.tmpDir != null) {
-            return ResourceLoader.tmpDir;
+    private static synchronized File getTmpDirectory() throws IOException {
+        if (tmpDir != null) {
+            return tmpDir;
         }
 
         String dirBase = System.getProperty("java.io.tmpdir");
         Random unsecureRandom = new Random(System.currentTimeMillis());
 
         // Get unique temporary directory
-        while (ResourceLoader.tmpDir == null) {
+        while (tmpDir == null) {
             String dirName = TMP_DIR_PREFIX + '-' + Long.toHexString(unsecureRandom.nextLong());
-            ResourceLoader.tmpDir = new File(dirBase, dirName);
+            tmpDir = new File(dirBase, dirName);
 
-            if (ResourceLoader.tmpDir.exists()) {
-                ResourceLoader.tmpDir = null;
+            if (tmpDir.exists()) {
+                tmpDir = null;
             }
         }
 
         // Create directory
-        if (!ResourceLoader.tmpDir.mkdir()) {
-            ResourceLoader.tmpDir = null;
+        if (!tmpDir.mkdir()) {
+            tmpDir = null;
             throw new IOException("No permission to create temporary directory");
         }
-        ResourceLoader.tmpDir.deleteOnExit();
+        tmpDir.deleteOnExit();
 
-        return ResourceLoader.tmpDir;
+        return tmpDir;
     }
 
-    private synchronized static File getArchDirectory() throws RuntimeException {
-        if (ResourceLoader.archDir != null) {
-            return ResourceLoader.archDir;
+    private static synchronized File getArchDirectory() throws RuntimeException {
+        if (archDir != null) {
+            return archDir;
         }
 
         String arch = System.getProperty("os.arch").toLowerCase();
 
         // Get normalized arch directory
         if (arch.matches("^(x86_64|amd64|x64|x86-64)$")) {
-            ResourceLoader.archDir = new File(JNI_BASE_DIR, "x86_64");
+            archDir = new File(JNI_BASE_DIR, "x86_64");
         } else if (arch.matches("^(x86|i386|ia-32|i686)$")) {
-            ResourceLoader.archDir = new File(JNI_BASE_DIR, "x86");
+            archDir = new File(JNI_BASE_DIR, "x86");
         } else if (arch.matches("^(aarch64|arm64|arm-v8)$")) {
-            ResourceLoader.archDir = new File(JNI_BASE_DIR, "arm64");
+            archDir = new File(JNI_BASE_DIR, "arm64");
         } else if (arch.matches("^(arm|arm-v7|armv7|arm32)$")) {
-            ResourceLoader.archDir = new File(JNI_BASE_DIR, "arm");
+            archDir = new File(JNI_BASE_DIR, "arm");
         } else {
             throw new RuntimeException("Unsupported CPU architecture: " + arch);
         }
 
-        return ResourceLoader.archDir;
+        return archDir;
     }
 
     private static String getLibNameByOs(String base) throws RuntimeException {


### PR DESCRIPTION
So we tried this lib in a setup where it it packaged inside a spring-boot jar, and it failed to load.

The error had no hint:

```
java.lang.UnsatisfiedLinkError: 'void com.linecorp.aesgcmsiv.AESGCMSIV.init(byte[])'
 	at com.linecorp.aesgcmsiv.AESGCMSIV.init(Native Method)
 	at com.linecorp.aesgcmsiv.AESGCMSIV.<init>(AESGCMSIV.java:52)
```

So hoping to get more details with this logging addition.