### PR TITLE
FIX: Refactor Java library ResourceLoader logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+
+- Update Java library `ReseourceLoader`:
+  - add a fallback on the class loader that is used when the Context class loader is `null`
+  - refactor code to have better handling of synchronized sections and to avoid loading the library multiple times
+
 ## 1.2.0
 
 - Add log information in the Java library when the ResourceLoader fails to load the native library

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,7 +19,7 @@ android.nonTransitiveRClass=true
 
 # Version constants
 VERSION_MAJOR = 1
-VERSION_MINOR = 2
+VERSION_MINOR = 3
 VERSION_PATCH = 0
 # Snapshot build
 snapshotBuild = true

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,6 +1,6 @@
 # Version constants
 VERSION_MAJOR = 1
-VERSION_MINOR = 2
+VERSION_MINOR = 3
 VERSION_PATCH = 0
 # Local and snapshot build
 localBuild = true


### PR DESCRIPTION
This PR improves the ResourceLoader in the Java library. Especially, it:
- simplifies the part of the code that is synchronized
- removes some unnecessary caching that was done on some variable
- removes the custom code to create a temporary directory, to use the standard function
- avoids loading the library several times in the case that the function is called several times
- adds a fallback on the Context ClassLoader if it is `null`, to use the class ClassLoader instead
- check early for the resource in the JAR, to avoid creating the temporary directory if it is not present

As the code doesn't break the API, only the minor version is bumped from `1.2.0` to `1.3.0`.