### PR TITLE
Update: simplification of JNI code

### DIFF
--- a/android/aesgcmsiv/src/androidTest/java/com/linecorp/aesgcmsiv/AESGCMSIVTest.java
+++ b/android/aesgcmsiv/src/androidTest/java/com/linecorp/aesgcmsiv/AESGCMSIVTest.java
@@ -18,14 +18,13 @@ package com.linecorp.aesgcmsiv;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
+import java.lang.reflect.Field;
 
 import javax.crypto.AEADBadTagException;
-
-import static org.junit.Assert.*;
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -34,1472 +33,435 @@ import static org.junit.Assert.*;
  */
 @RunWith(AndroidJUnit4.class)
 public class AESGCMSIVTest {
+    private static final String[][] TESTS_KAT_128 = {
+            {"", "", "01000000000000000000000000000000", "030000000000000000000000", "dc20e2d83f25705bb49e439eca56de25"},
+            {"0100000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "b5d839330ac7b786578782fff6013b815b287c22493a364c"},
+            {"010000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "7323ea61d05932260047d942a4978db357391a0bc4fdec8b0d106639"},
+            {"01000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "743f7c8077ab25f8624e2e948579cf77303aaf90f6fe21199c6068577437a0c4"},
+            {"0100000000000000000000000000000002000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "84e07e62ba83a6585417245d7ec413a9fe427d6315c09b57ce45f2e3936a94451a8e45dcd4578c667cd86847bf6155ff"},
+            {"010000000000000000000000000000000200000000000000000000000000000003000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "3fd24ce1f5a67b75bf2351f181a475c7b800a5b4d3dcf70106b1eea82fa1d64df42bf7226122fa92e17a40eeaac1201b5e6e311dbf395d35b0fe39c2714388f8"},
+            {"01000000000000000000000000000000020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "2433668f1058190f6d43e360f4f35cd8e475127cfca7028ea8ab5c20f7ab2af02516a2bdcbc08d521be37ff28c152bba36697f25b4cd169c6590d1dd39566d3f8a263dd317aa88d56bdf3936dba75bb8"},
+            {"0200000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "1e6daba35669f4273b0a1a2560969cdf790d99759abd1508"},
+            {"020000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "296c7889fd99f41917f4462008299c5102745aaa3a0c469fad9e075a"},
+            {"02000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "e2b0c5da79a901c1745f700525cb335b8f8936ec039e4e4bb97ebd8c4457441f"},
+            {"0200000000000000000000000000000003000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "620048ef3c1e73e57e02bb8562c416a319e73e4caac8e96a1ecb2933145a1d71e6af6a7f87287da059a71684ed3498e1"},
+            {"020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "50c8303ea93925d64090d07bd109dfd9515a5a33431019c17d93465999a8b0053201d723120a8562b838cdff25bf9d1e6a8cc3865f76897c2e4b245cf31c51f2"},
+            {"02000000000000000000000000000000030000000000000000000000000000000400000000000000000000000000000005000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "2f5c64059db55ee0fb847ed513003746aca4e61c711b5de2e7a77ffd02da42feec601910d3467bb8b36ebbaebce5fba30d36c95f48a3e7980f0e7ac299332a80cdc46ae475563de037001ef84ae21744"},
+            {"02000000", "010000000000000000000000", "01000000000000000000000000000000", "030000000000000000000000", "a8fe3e8707eb1f84fb28f8cb73de8e99e2f48a14"},
+            {"0300000000000000000000000000000004000000", "010000000000000000000000000000000200", "01000000000000000000000000000000", "030000000000000000000000", "6bb0fecf5ded9b77f902c7d5da236a4391dd029724afc9805e976f451e6d87f6fe106514"},
+            {"030000000000000000000000000000000400", "0100000000000000000000000000000002000000", "01000000000000000000000000000000", "030000000000000000000000", "44d0aaf6fb2f1f34add5e8064e83e12a2adabff9b2ef00fb47920cc72a0c0f13b9fd"},
+            {"", "", "e66021d5eb8e4f4066d4adb9c33560e4", "f46e44bb3da0015c94f70887", "a4194b79071b01a87d65f706e3949578"},
+            {"7a806c", "46bb91c3c5", "36864200e0eaf5284d884a0e77d31646", "bae8e37fc83441b16034566b", "af60eb711bd85bc1e4d3e0a462e074eea428a8"},
+            {"bdc66f146545", "fc880c94a95198874296", "aedb64a6c590bc84d1a5e269e4b47801", "afc0577e34699b9e671fdd4f", "bb93a3e34d3cd6a9c45545cfc11f03ad743dba20f966"},
+            {"1177441f195495860f", "046787f3ea22c127aaf195d1894728", "d5cc1fd161320b6920ce07787f86743b", "275d1ab32f6d1f0434d8848c", "4f37281f7ad12949d01d02fd0cd174c84fc5dae2f60f52fd2b"},
+            {"9f572c614b4745914474e7c7", "c9882e5386fd9f92ec489c8fde2be2cf97e74e93", "b3fed1473c528b8426a582995929a149", "9e9ad8780c8d63d0ab4149c0", "f54673c5ddf710c745641c8bc1dc2f871fb7561da1286e655e24b7b0"},
+            {"0d8c8451178082355c9e940fea2f58", "2950a70d5a1db2316fd568378da107b52b0da55210cc1c1b0a", "2d4ed87da44102952ef94b02b805249b", "ac80e6f61455bfac8308a2d4", "c9ff545e07b88a015f05b274540aa183b3449b9f39552de99dc214a1190b0b"},
+            {"6b3db4da3d57aa94842b9803a96e07fb6de7", "1860f762ebfbd08284e421702de0de18baa9c9596291b08466f37de21c7f", "bde3b2f204d1e9f8b06bc47f9745b3d1", "ae06556fb6aa7890bebc18fe", "6298b296e24e8cc35dce0bed484b7f30d5803e377094f04709f64d7b985310a4db84"},
+            {"e42a3c02c25b64869e146d7b233987bddfc240871d", "7576f7028ec6eb5ea7e298342a94d4b202b370ef9768ec6561c4fe6b7e7296fa859c21", "f901cfe8a69615a93fdf7a98cad48179", "6245709fb18853f68d833640", "391cc328d484a4f46406181bcd62efd9b3ee197d052d15506c84a9edd65e13e9d24a2a6e70"}
+    };
+
+    private static final String[][] TESTS_KAT_256 = {
+            {"", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "07f5f4169bbf55a8400cd47ea6fd400f"},
+            {"0100000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c2ef328e5c71c83b843122130f7364b761e0b97427e3df28"},
+            {"010000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "9aab2aeb3faa0a34aea8e2b18ca50da9ae6559e48fd10f6e5c9ca17e"},
+            {"01000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "85a01b63025ba19b7fd3ddfc033b3e76c9eac6fa700942702e90862383c6c366"},
+            {"0100000000000000000000000000000002000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "4a6a9db4c8c6549201b9edb53006cba821ec9cf850948a7c86c68ac7539d027fe819e63abcd020b006a976397632eb5d"},
+            {"010000000000000000000000000000000200000000000000000000000000000003000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c00d121893a9fa603f48ccc1ca3c57ce7499245ea0046db16c53c7c66fe717e39cf6c748837b61f6ee3adcee17534ed5790bc96880a99ba804bd12c0e6a22cc4"},
+            {"01000000000000000000000000000000020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c2d5160a1f8683834910acdafc41fbb1632d4a353e8b905ec9a5499ac34f96c7e1049eb080883891a4db8caaa1f99dd004d80487540735234e3744512c6f90ce112864c269fc0d9d88c61fa47e39aa08"},
+            {"0200000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "1de22967237a813291213f267e3b452f02d01ae33e4ec854"},
+            {"020000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "163d6f9cc1b346cd453a2e4cc1a4a19ae800941ccdc57cc8413c277f"},
+            {"02000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c91545823cc24f17dbb0e9e807d5ec17b292d28ff61189e8e49f3875ef91aff7"},
+            {"0200000000000000000000000000000003000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "07dad364bfc2b9da89116d7bef6daaaf6f255510aa654f920ac81b94e8bad365aea1bad12702e1965604374aab96dbbc"},
+            {"020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c67a1f0f567a5198aa1fcc8e3f21314336f7f51ca8b1af61feac35a86416fa47fbca3b5f749cdf564527f2314f42fe2503332742b228c647173616cfd44c54eb"},
+            {"02000000000000000000000000000000030000000000000000000000000000000400000000000000000000000000000005000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "67fd45e126bfb9a79930c43aad2d36967d3f0e4d217c1e551f59727870beefc98cb933a8fce9de887b1e40799988db1fc3f91880ed405b2dd298318858467c895bde0285037c5de81e5b570a049b62a0"},
+            {"02000000", "010000000000000000000000", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "22b3f4cd1835e517741dfddccfa07fa4661b74cf"},
+            {"0300000000000000000000000000000004000000", "010000000000000000000000000000000200", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "43dd0163cdb48f9fe3212bf61b201976067f342bb879ad976d8242acc188ab59cabfe307"},
+            {"030000000000000000000000000000000400", "0100000000000000000000000000000002000000", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "462401724b5ce6588d5a54aae5375513a075cfcdf5042112aa29685c912fc2056543"},
+            {"", "", "e66021d5eb8e4f4066d4adb9c33560e4f46e44bb3da0015c94f7088736864200", "e0eaf5284d884a0e77d31646", "169fbb2fbf389a995f6390af22228a62"},
+            {"671fdd", "4fbdc66f14", "bae8e37fc83441b16034566b7a806c46bb91c3c5aedb64a6c590bc84d1a5e269", "e4b47801afc0577e34699b9e", "0eaccb93da9bb81333aee0c785b240d319719d"},
+            {"195495860f04", "6787f3ea22c127aaf195", "6545fc880c94a95198874296d5cc1fd161320b6920ce07787f86743b275d1ab3", "2f6d1f0434d8848c1177441f", "a254dad4f3f96b62b84dc40c84636a5ec12020ec8c2c"},
+            {"c9882e5386fd9f92ec", "489c8fde2be2cf97e74e932d4ed87d", "d1894728b3fed1473c528b8426a582995929a1499e9ad8780c8d63d0ab4149c0", "9f572c614b4745914474e7c7", "0df9e308678244c44bc0fd3dc6628dfe55ebb0b9fb2295c8c2"},
+            {"1db2316fd568378da107b52b", "0da55210cc1c1b0abde3b2f204d1e9f8b06bc47f", "a44102952ef94b02b805249bac80e6f61455bfac8308a2d40d8c845117808235", "5c9e940fea2f582950a70d5a", "8dbeb9f7255bf5769dd56692404099c2587f64979f21826706d497d5"},
+            {"21702de0de18baa9c9596291b08466", "f37de21c7ff901cfe8a69615a93fdf7a98cad481796245709f", "9745b3d1ae06556fb6aa7890bebc18fe6b3db4da3d57aa94842b9803a96e07fb", "6de71860f762ebfbd08284e4", "793576dfa5c0f88729a7ed3c2f1bffb3080d28f6ebb5d3648ce97bd5ba67fd"},
+            {"b202b370ef9768ec6561c4fe6b7e7296fa85", "9c2159058b1f0fe91433a5bdc20e214eab7fecef4454a10ef0657df21ac7", "b18853f68d833640e42a3c02c25b64869e146d7b233987bddfc240871d7576f7", "028ec6eb5ea7e298342a94d4", "857e16a64915a787637687db4a9519635cdd454fc2a154fea91f8363a39fec7d0a49"},
+            {"ced532ce4159b035277d4dfbb7db62968b13cd4eec", "734320ccc9d9bbbb19cb81b2af4ecbc3e72834321f7aa0f70b7282b4f33df23f167541", "3c535de192eaed3822a2fbbe2ca9dfc88255e14a661b8aa82cc54236093bbc23", "688089e55540db1872504e1c", "626660c26ea6612fb17ad91e8e767639edd6c9faee9d6c7029675b89eaf4ba1ded1a286594"}
+    };
+
+    private static final String[][] TESTS_KAT_WRAP = {
+            {"000000000000000000000000000000004db923dc793ee6497c76dcc03a98e108", "", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000", "f3f80f2cf0cb2dd9c5984fcda908456cc537703b5ba70324a6793a7bf218d3eaffffffff000000000000000000000000"},
+            {"eb3640277c7ffd1303c7a542d02d3e4c0000000000000000", "", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000", "18ce4f0b8cb4d0cac65fea8f79257b20888e53e72299e56dffffffff000000000000000000000000"}
+    };
+
+    private static byte[] fromHex(String hex) {
+        if ((hex.length() % 2) != 0) {
+            throw new IllegalArgumentException("Invalid hex string: " + hex);
+        }
+
+        byte[] result = new byte[hex.length() / 2];
+
+        for (int i = 0; i < result.length; ++i) {
+            int hi = Character.digit(hex.charAt(2 * i), 16);
+            int lo = Character.digit(hex.charAt((2 * i) + 1), 16);
+            result[i] = (byte) ((hi << 4) + lo);
+        }
+
+        return result;
+    }
+
     @Test
     public void apiInit() {
         // Test with null key
-        {
-            try {
-                new AESGCMSIV(null);
-                fail();
-            } catch (Exception e) {
-                assertTrue(true);
-            }
+        try {
+            new AESGCMSIV(null);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid size for key
-        {
-            byte[] key = new byte[8];
-
-            try {
-                new AESGCMSIV(key);
-                fail();
-            } catch (Exception e) {
-                assertTrue(true);
-            }
+        try {
+            new AESGCMSIV(new byte[8]);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test when all goes well
-        {
-            byte[] key = new byte[16];
+        new AESGCMSIV(new byte[16]);
+    }
 
+    @Test
+    public void apiFinalize() throws NoSuchFieldException, IllegalAccessException {
+        // Make aesGcmSivContext field public for this test
+        Field aesGcmSivContext = AESGCMSIV.class.getDeclaredField("aesGcmSivContext");
+        aesGcmSivContext.setAccessible(true);
+
+        try {
+            AESGCMSIV ctx;
+
+            // Finalize on null context
             try {
-                new AESGCMSIV(key);
-            } catch (Exception e) {
-                fail();
+                AESGCMSIV tmp = null;
+                tmp.finalize();
+                Assert.fail();
+            } catch (NullPointerException ignored) {
             }
+
+            // Finalize on normal context
+            ctx = new AESGCMSIV(new byte[16]);
+            Assert.assertNotEquals(0, aesGcmSivContext.getLong(ctx));
+
+            ctx.finalize();
+            Assert.assertEquals(0, aesGcmSivContext.getLong(ctx));
+
+            // Finalize twice on normal context
+            ctx = new AESGCMSIV(new byte[16]);
+            Assert.assertNotEquals(0, aesGcmSivContext.getLong(ctx));
+
+            ctx.finalize();
+            Assert.assertEquals(0, aesGcmSivContext.getLong(ctx));
+            ctx.finalize();
+            Assert.assertEquals(0, aesGcmSivContext.getLong(ctx));
+        } finally {
+            aesGcmSivContext.setAccessible(false);
         }
     }
 
     @Test
     public void apiEncrypt() {
-        // Test with null ctx
-        {
-            AESGCMSIV ctx = null;
+        AESGCMSIV ctx = new AESGCMSIV(new byte[16]);
+        byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
+        byte[] aad = new byte[16];
+        byte[] plaintext = new byte[16];
+        byte[] ciphertext;
 
-            try {
-                ctx.encrypt(null, null, null);
-                fail();
-            } catch (NullPointerException e) {
-                assertTrue(true);
-            }
+        // Test with null ctx
+        try {
+            AESGCMSIV tmp = null;
+            tmp.encrypt(nonce, plaintext, aad);
+            Assert.fail();
+        } catch (NullPointerException ignored) {
         }
 
         // Test with null nonce
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.encrypt(null, null, null);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            }
+        try {
+            ctx.encrypt(null, plaintext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid nonce size
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[8];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.encrypt(nonce, null, null);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            }
+        try {
+            ctx.encrypt(new byte[8], plaintext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test when all goes well
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[10];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
+        ciphertext = ctx.encrypt(nonce, plaintext, aad);
+        Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-            ctx = new AESGCMSIV(key);
+        // Test when all goes well, but plaintext == null
+        ciphertext = ctx.encrypt(nonce, null, aad);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
+        // Test when all goes well, but plaintext size == 0
+        ciphertext = ctx.encrypt(nonce, new byte[0], aad);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-        // Test when all goes well, but nothing to encrypt (plaintext == null)
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
+        // Test when all goes well, but aad == null
+        ciphertext = ctx.encrypt(nonce, plaintext, null);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE + plaintext.length, ciphertext.length);
 
-            ctx = new AESGCMSIV(key);
+        // Test when all goes well, but aad size == 0
+        ciphertext = ctx.encrypt(nonce, plaintext, new byte[0]);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE + plaintext.length, ciphertext.length);
 
-            ciphertext = ctx.encrypt(nonce, null, aad);
-            assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
+        // Test when all goes well, but plaintext and aad == null
+        ciphertext = ctx.encrypt(nonce, null, null);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-        // Test when all goes well, but nothing to encrypt (plaintext size is 0)
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[0];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            ctx = new AESGCMSIV(key);
-
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
-
-        // Test when all goes well, but no aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[0];
-            byte[] ciphertext;
-
-            ctx = new AESGCMSIV(key);
-
-            ciphertext = ctx.encrypt(nonce, plaintext, null);
-            assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
-
-        // Test when all goes well, but no plaintext nor aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-
-            ctx = new AESGCMSIV(key);
-
-            ciphertext = ctx.encrypt(nonce, null, null);
-            assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
+        // Test when all goes well, but plaintext and aad size == 0
+        ciphertext = ctx.encrypt(nonce, new byte[0], new byte[0]);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
     }
 
     @Test
-    public void apiDecrypt() {
-        // Test with null ctx
-        {
-            AESGCMSIV ctx = null;
+    public void apiDecrypt() throws AEADBadTagException {
+        AESGCMSIV ctx = new AESGCMSIV(new byte[16]);
+        byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
+        byte[] aad = new byte[16];
+        byte[] plaintext = new byte[16];
+        byte[] ciphertext = ctx.encrypt(nonce, plaintext, aad);
+        byte[] decrypttext;
 
-            try {
-                ctx.decrypt(null, null, null);
-                fail();
-            } catch (NullPointerException e) {
-                assertTrue(true);
-            } catch (AEADBadTagException e) {
-                fail();
-            }
+        // Test with null ctx
+        try {
+            AESGCMSIV tmp = null;
+            tmp.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (NullPointerException ignored) {
         }
 
         // Test with null nonce
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.decrypt(null, null, null);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            } catch (AEADBadTagException e) {
-                fail();
-            }
+        try {
+            ctx.decrypt(null, ciphertext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid nonce size
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[8];
+        try {
+            ctx.decrypt(new byte[8], ciphertext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
+        }
 
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.decrypt(nonce, null, null);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            } catch (AEADBadTagException e) {
-                fail();
-            }
+        // Test with null ciphertext
+        try {
+            ctx.decrypt(nonce, null, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid ciphertext size
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext = new byte[AESGCMSIV.TAG_SIZE - 1];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertTrue(true);
-            } catch (AEADBadTagException e) {
-                fail();
-            }
+        try {
+            ctx.decrypt(nonce, new byte[AESGCMSIV.TAG_SIZE - 1], aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test when all goes well
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-            byte[] decrypttext;
+        decrypttext = ctx.decrypt(nonce, ciphertext, aad);
+        Assert.assertArrayEquals(plaintext, decrypttext);
 
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
+        // Test when all goes well, but plaintext size == 0
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, null, aad), aad);
+        Assert.assertArrayEquals(new byte[0], decrypttext);
 
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                assertArrayEquals(plaintext, decrypttext);
-            } catch (Exception e) {
-                fail();
-            }
-        }
+        // Test when all goes well, but aad == null
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, plaintext, null), null);
+        Assert.assertArrayEquals(plaintext, decrypttext);
 
-        // Test when all goes well , but nothing to decrypt
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-            byte[] decrypttext;
+        // Test when all goes well, but no plaintext and aad == null
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, null, null), null);
+        Assert.assertArrayEquals(new byte[0], decrypttext);
 
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, null, null);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, null);
-                assertArrayEquals(new byte[0], decrypttext);
-            } catch (Exception e) {
-                fail();
-            }
-        }
-
-        // Test when all goes well , but no aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-            byte[] decrypttext;
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, null);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, null);
-                assertArrayEquals(plaintext, decrypttext);
-            } catch (Exception e) {
-                fail();
-            }
-        }
-
-        // Test when all goes well, but no plaintext nor aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-            byte[] decrypttext;
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, null, null);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, null);
-                assertArrayEquals(new byte[0], decrypttext);
-            } catch (Exception e) {
-                fail();
-            }
-        }
+        // Test when all goes well, but no plaintext and aad size == 0
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, null, new byte[0]), new byte[0]);
+        Assert.assertArrayEquals(new byte[0], decrypttext);
     }
 
     @Test
     public void badDecrypt() {
+        AESGCMSIV ctx = new AESGCMSIV(new byte[16]);
+        byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
+        byte[] aad = new byte[16];
+        byte[] plaintext = new byte[16];
+        byte[] ciphertext;
+
         // No plaintext, no AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, null, null);
-            assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // No plaintext, AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(aad, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, null, aad);
-            assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, no AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, null);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, no AAD, error on ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, null);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, no AAD, error both tag and ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, null);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-            Arrays.fill(aad, (byte) 0x03);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, AAD, error on ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-            Arrays.fill(aad, (byte) 0x03);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, AAD, error on both tag and ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-            Arrays.fill(aad, (byte) 0x03);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                fail();
-            } catch (AEADBadTagException e) {
-                assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
     }
 
     @Test
     public void katEncrypt128() {
-        String[][] tests = {
-                {"", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "dc20e2d83f25705bb49e439eca56de25"},
-                {"0100000000000000", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "b5d839330ac7b786578782fff6013b81" +
-                                "5b287c22493a364c"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "7323ea61d05932260047d942a4978db3" +
-                                "57391a0bc4fdec8b0d106639"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "743f7c8077ab25f8624e2e948579cf77" +
-                                "303aaf90f6fe21199c6068577437a0c4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "84e07e62ba83a6585417245d7ec413a9" +
-                                "fe427d6315c09b57ce45f2e3936a9445" +
-                                "1a8e45dcd4578c667cd86847bf6155ff"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "3fd24ce1f5a67b75bf2351f181a475c7" +
-                                "b800a5b4d3dcf70106b1eea82fa1d64d" +
-                                "f42bf7226122fa92e17a40eeaac1201b" +
-                                "5e6e311dbf395d35b0fe39c2714388f8"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2433668f1058190f6d43e360f4f35cd8" +
-                                "e475127cfca7028ea8ab5c20f7ab2af0" +
-                                "2516a2bdcbc08d521be37ff28c152bba" +
-                                "36697f25b4cd169c6590d1dd39566d3f" +
-                                "8a263dd317aa88d56bdf3936dba75bb8"},
-                {"0200000000000000", "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1e6daba35669f4273b0a1a2560969cdf" +
-                                "790d99759abd1508"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "296c7889fd99f41917f4462008299c51" +
-                                "02745aaa3a0c469fad9e075a"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "e2b0c5da79a901c1745f700525cb335b" +
-                                "8f8936ec039e4e4bb97ebd8c4457441f"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "620048ef3c1e73e57e02bb8562c416a3" +
-                                "19e73e4caac8e96a1ecb2933145a1d71" +
-                                "e6af6a7f87287da059a71684ed3498e1"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "50c8303ea93925d64090d07bd109dfd9" +
-                                "515a5a33431019c17d93465999a8b005" +
-                                "3201d723120a8562b838cdff25bf9d1e" +
-                                "6a8cc3865f76897c2e4b245cf31c51f2"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2f5c64059db55ee0fb847ed513003746" +
-                                "aca4e61c711b5de2e7a77ffd02da42fe" +
-                                "ec601910d3467bb8b36ebbaebce5fba3" +
-                                "0d36c95f48a3e7980f0e7ac299332a80" +
-                                "cdc46ae475563de037001ef84ae21744"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "a8fe3e8707eb1f84fb28f8cb73de8e99" +
-                                "e2f48a14"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "6bb0fecf5ded9b77f902c7d5da236a43" +
-                                "91dd029724afc9805e976f451e6d87f6" +
-                                "fe106514"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "44d0aaf6fb2f1f34add5e8064e83e12a" +
-                                "2adabff9b2ef00fb47920cc72a0c0f13" +
-                                "b9fd"},
-                {"", "", "e66021d5eb8e4f4066d4adb9c33560e4",
-                        "f46e44bb3da0015c94f70887",
-                        "a4194b79071b01a87d65f706e3949578"},
-                {"7a806c", "46bb91c3c5", "36864200e0eaf5284d884a0e77d31646",
-                        "bae8e37fc83441b16034566b",
-                        "af60eb711bd85bc1e4d3e0a462e074ee" +
-                                "a428a8"},
-                {"bdc66f146545", "fc880c94a95198874296",
-                        "aedb64a6c590bc84d1a5e269e4b47801",
-                        "afc0577e34699b9e671fdd4f",
-                        "bb93a3e34d3cd6a9c45545cfc11f03ad" +
-                                "743dba20f966"},
-                {"1177441f195495860f", "046787f3ea22c127aaf195d1894728",
-                        "d5cc1fd161320b6920ce07787f86743b",
-                        "275d1ab32f6d1f0434d8848c",
-                        "4f37281f7ad12949d01d02fd0cd174c8" +
-                                "4fc5dae2f60f52fd2b"},
-                {"9f572c614b4745914474e7c7",
-                        "c9882e5386fd9f92ec489c8fde2be2cf" +
-                                "97e74e93",
-                        "b3fed1473c528b8426a582995929a149",
-                        "9e9ad8780c8d63d0ab4149c0",
-                        "f54673c5ddf710c745641c8bc1dc2f87" +
-                                "1fb7561da1286e655e24b7b0"},
-                {"0d8c8451178082355c9e940fea2f58",
-                        "2950a70d5a1db2316fd568378da107b5" +
-                                "2b0da55210cc1c1b0a",
-                        "2d4ed87da44102952ef94b02b805249b",
-                        "ac80e6f61455bfac8308a2d4",
-                        "c9ff545e07b88a015f05b274540aa183" +
-                                "b3449b9f39552de99dc214a1190b0b"},
-                {"6b3db4da3d57aa94842b9803a96e07fb" +
-                        "6de7",
-                        "1860f762ebfbd08284e421702de0de18" +
-                                "baa9c9596291b08466f37de21c7f",
-                        "bde3b2f204d1e9f8b06bc47f9745b3d1",
-                        "ae06556fb6aa7890bebc18fe",
-                        "6298b296e24e8cc35dce0bed484b7f30" +
-                                "d5803e377094f04709f64d7b985310a4" +
-                                "db84"},
-                {"e42a3c02c25b64869e146d7b233987bd" +
-                        "dfc240871d",
-                        "7576f7028ec6eb5ea7e298342a94d4b2" +
-                                "02b370ef9768ec6561c4fe6b7e7296fa" +
-                                "859c21",
-                        "f901cfe8a69615a93fdf7a98cad48179",
-                        "6245709fb18853f68d833640",
-                        "391cc328d484a4f46406181bcd62efd9" +
-                                "b3ee197d052d15506c84a9edd65e13e9" +
-                                "d24a2a6e70"}
-        };
+        for (String[] test : TESTS_KAT_128) {
+            byte[] plaintext = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] expected = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            assertArrayEquals(expected, ciphertext);
+            byte[] ciphertext = new AESGCMSIV(key).encrypt(nonce, plaintext, aad);
+            Assert.assertArrayEquals(expected, ciphertext);
         }
     }
 
     @Test
-    public void katDecrypt128() {
-        String[][] tests = {
-                {"", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "dc20e2d83f25705bb49e439eca56de25"},
-                {"0100000000000000", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "b5d839330ac7b786578782fff6013b81" +
-                                "5b287c22493a364c"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "7323ea61d05932260047d942a4978db3" +
-                                "57391a0bc4fdec8b0d106639"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "743f7c8077ab25f8624e2e948579cf77" +
-                                "303aaf90f6fe21199c6068577437a0c4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "84e07e62ba83a6585417245d7ec413a9" +
-                                "fe427d6315c09b57ce45f2e3936a9445" +
-                                "1a8e45dcd4578c667cd86847bf6155ff"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "3fd24ce1f5a67b75bf2351f181a475c7" +
-                                "b800a5b4d3dcf70106b1eea82fa1d64d" +
-                                "f42bf7226122fa92e17a40eeaac1201b" +
-                                "5e6e311dbf395d35b0fe39c2714388f8"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2433668f1058190f6d43e360f4f35cd8" +
-                                "e475127cfca7028ea8ab5c20f7ab2af0" +
-                                "2516a2bdcbc08d521be37ff28c152bba" +
-                                "36697f25b4cd169c6590d1dd39566d3f" +
-                                "8a263dd317aa88d56bdf3936dba75bb8"},
-                {"0200000000000000", "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1e6daba35669f4273b0a1a2560969cdf" +
-                                "790d99759abd1508"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "296c7889fd99f41917f4462008299c51" +
-                                "02745aaa3a0c469fad9e075a"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "e2b0c5da79a901c1745f700525cb335b" +
-                                "8f8936ec039e4e4bb97ebd8c4457441f"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "620048ef3c1e73e57e02bb8562c416a3" +
-                                "19e73e4caac8e96a1ecb2933145a1d71" +
-                                "e6af6a7f87287da059a71684ed3498e1"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "50c8303ea93925d64090d07bd109dfd9" +
-                                "515a5a33431019c17d93465999a8b005" +
-                                "3201d723120a8562b838cdff25bf9d1e" +
-                                "6a8cc3865f76897c2e4b245cf31c51f2"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2f5c64059db55ee0fb847ed513003746" +
-                                "aca4e61c711b5de2e7a77ffd02da42fe" +
-                                "ec601910d3467bb8b36ebbaebce5fba3" +
-                                "0d36c95f48a3e7980f0e7ac299332a80" +
-                                "cdc46ae475563de037001ef84ae21744"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "a8fe3e8707eb1f84fb28f8cb73de8e99" +
-                                "e2f48a14"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "6bb0fecf5ded9b77f902c7d5da236a43" +
-                                "91dd029724afc9805e976f451e6d87f6" +
-                                "fe106514"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "44d0aaf6fb2f1f34add5e8064e83e12a" +
-                                "2adabff9b2ef00fb47920cc72a0c0f13" +
-                                "b9fd"},
-                {"", "", "e66021d5eb8e4f4066d4adb9c33560e4",
-                        "f46e44bb3da0015c94f70887",
-                        "a4194b79071b01a87d65f706e3949578"},
-                {"7a806c", "46bb91c3c5", "36864200e0eaf5284d884a0e77d31646",
-                        "bae8e37fc83441b16034566b",
-                        "af60eb711bd85bc1e4d3e0a462e074ee" +
-                                "a428a8"},
-                {"bdc66f146545", "fc880c94a95198874296",
-                        "aedb64a6c590bc84d1a5e269e4b47801",
-                        "afc0577e34699b9e671fdd4f",
-                        "bb93a3e34d3cd6a9c45545cfc11f03ad" +
-                                "743dba20f966"},
-                {"1177441f195495860f", "046787f3ea22c127aaf195d1894728",
-                        "d5cc1fd161320b6920ce07787f86743b",
-                        "275d1ab32f6d1f0434d8848c",
-                        "4f37281f7ad12949d01d02fd0cd174c8" +
-                                "4fc5dae2f60f52fd2b"},
-                {"9f572c614b4745914474e7c7",
-                        "c9882e5386fd9f92ec489c8fde2be2cf" +
-                                "97e74e93",
-                        "b3fed1473c528b8426a582995929a149",
-                        "9e9ad8780c8d63d0ab4149c0",
-                        "f54673c5ddf710c745641c8bc1dc2f87" +
-                                "1fb7561da1286e655e24b7b0"},
-                {"0d8c8451178082355c9e940fea2f58",
-                        "2950a70d5a1db2316fd568378da107b5" +
-                                "2b0da55210cc1c1b0a",
-                        "2d4ed87da44102952ef94b02b805249b",
-                        "ac80e6f61455bfac8308a2d4",
-                        "c9ff545e07b88a015f05b274540aa183" +
-                                "b3449b9f39552de99dc214a1190b0b"},
-                {"6b3db4da3d57aa94842b9803a96e07fb" +
-                        "6de7",
-                        "1860f762ebfbd08284e421702de0de18" +
-                                "baa9c9596291b08466f37de21c7f",
-                        "bde3b2f204d1e9f8b06bc47f9745b3d1",
-                        "ae06556fb6aa7890bebc18fe",
-                        "6298b296e24e8cc35dce0bed484b7f30" +
-                                "d5803e377094f04709f64d7b985310a4" +
-                                "db84"},
-                {"e42a3c02c25b64869e146d7b233987bd" +
-                        "dfc240871d",
-                        "7576f7028ec6eb5ea7e298342a94d4b2" +
-                                "02b370ef9768ec6561c4fe6b7e7296fa" +
-                                "859c21",
-                        "f901cfe8a69615a93fdf7a98cad48179",
-                        "6245709fb18853f68d833640",
-                        "391cc328d484a4f46406181bcd62efd9" +
-                                "b3ee197d052d15506c84a9edd65e13e9" +
-                                "d24a2a6e70"}
-        };
+    public void katDecrypt128() throws AEADBadTagException {
+        for (String[] test : TESTS_KAT_128) {
+            byte[] expected = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] ciphertext = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] decrypttext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            assertArrayEquals(expected, ciphertext);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                assertArrayEquals(plaintext, decrypttext);
-            } catch (AEADBadTagException e) {
-                fail();
-            }
+            byte[] decrypttext = new AESGCMSIV(key).decrypt(nonce, ciphertext, aad);
+            Assert.assertArrayEquals(expected, decrypttext);
         }
     }
 
     @Test
     public void katEncrypt256() {
-        String[][] tests = {
-                {"", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07f5f4169bbf55a8400cd47ea6fd400f"},
-                {"0100000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2ef328e5c71c83b843122130f7364b7" +
-                                "61e0b97427e3df28"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "9aab2aeb3faa0a34aea8e2b18ca50da9" +
-                                "ae6559e48fd10f6e5c9ca17e"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "85a01b63025ba19b7fd3ddfc033b3e76" +
-                                "c9eac6fa700942702e90862383c6c366"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "4a6a9db4c8c6549201b9edb53006cba8" +
-                                "21ec9cf850948a7c86c68ac7539d027f" +
-                                "e819e63abcd020b006a976397632eb5d"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c00d121893a9fa603f48ccc1ca3c57ce" +
-                                "7499245ea0046db16c53c7c66fe717e3" +
-                                "9cf6c748837b61f6ee3adcee17534ed5" +
-                                "790bc96880a99ba804bd12c0e6a22cc4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2d5160a1f8683834910acdafc41fbb1" +
-                                "632d4a353e8b905ec9a5499ac34f96c7" +
-                                "e1049eb080883891a4db8caaa1f99dd0" +
-                                "04d80487540735234e3744512c6f90ce" +
-                                "112864c269fc0d9d88c61fa47e39aa08"},
-                {"0200000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1de22967237a813291213f267e3b452f" +
-                                "02d01ae33e4ec854"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "163d6f9cc1b346cd453a2e4cc1a4a19a" +
-                                "e800941ccdc57cc8413c277f"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c91545823cc24f17dbb0e9e807d5ec17" +
-                                "b292d28ff61189e8e49f3875ef91aff7"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07dad364bfc2b9da89116d7bef6daaaf" +
-                                "6f255510aa654f920ac81b94e8bad365" +
-                                "aea1bad12702e1965604374aab96dbbc"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c67a1f0f567a5198aa1fcc8e3f213143" +
-                                "36f7f51ca8b1af61feac35a86416fa47" +
-                                "fbca3b5f749cdf564527f2314f42fe25" +
-                                "03332742b228c647173616cfd44c54eb"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "67fd45e126bfb9a79930c43aad2d3696" +
-                                "7d3f0e4d217c1e551f59727870beefc9" +
-                                "8cb933a8fce9de887b1e40799988db1f" +
-                                "c3f91880ed405b2dd298318858467c89" +
-                                "5bde0285037c5de81e5b570a049b62a0"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "22b3f4cd1835e517741dfddccfa07fa4" +
-                                "661b74cf"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "43dd0163cdb48f9fe3212bf61b201976" +
-                                "067f342bb879ad976d8242acc188ab59" +
-                                "cabfe307"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "462401724b5ce6588d5a54aae5375513" +
-                                "a075cfcdf5042112aa29685c912fc205" +
-                                "6543"},
-                {"", "",
-                        "e66021d5eb8e4f4066d4adb9c33560e4" +
-                                "f46e44bb3da0015c94f7088736864200",
-                        "e0eaf5284d884a0e77d31646",
-                        "169fbb2fbf389a995f6390af22228a62"},
-                {"671fdd", "4fbdc66f14",
-                        "bae8e37fc83441b16034566b7a806c46" +
-                                "bb91c3c5aedb64a6c590bc84d1a5e269",
-                        "e4b47801afc0577e34699b9e",
-                        "0eaccb93da9bb81333aee0c785b240d3" +
-                                "19719d"},
-                {"195495860f04", "6787f3ea22c127aaf195",
-                        "6545fc880c94a95198874296d5cc1fd1" +
-                                "61320b6920ce07787f86743b275d1ab3",
-                        "2f6d1f0434d8848c1177441f",
-                        "a254dad4f3f96b62b84dc40c84636a5e" +
-                                "c12020ec8c2c"},
-                {"c9882e5386fd9f92ec", "489c8fde2be2cf97e74e932d4ed87d",
-                        "d1894728b3fed1473c528b8426a58299" +
-                                "5929a1499e9ad8780c8d63d0ab4149c0",
-                        "9f572c614b4745914474e7c7",
-                        "0df9e308678244c44bc0fd3dc6628dfe" +
-                                "55ebb0b9fb2295c8c2"},
-                {"1db2316fd568378da107b52b",
-                        "0da55210cc1c1b0abde3b2f204d1e9f8" +
-                                "b06bc47f",
-                        "a44102952ef94b02b805249bac80e6f6" +
-                                "1455bfac8308a2d40d8c845117808235",
-                        "5c9e940fea2f582950a70d5a",
-                        "8dbeb9f7255bf5769dd56692404099c2" +
-                                "587f64979f21826706d497d5"},
-                {"21702de0de18baa9c9596291b08466",
-                        "f37de21c7ff901cfe8a69615a93fdf7a" +
-                                "98cad481796245709f",
-                        "9745b3d1ae06556fb6aa7890bebc18fe" +
-                                "6b3db4da3d57aa94842b9803a96e07fb",
-                        "6de71860f762ebfbd08284e4",
-                        "793576dfa5c0f88729a7ed3c2f1bffb3" +
-                                "080d28f6ebb5d3648ce97bd5ba67fd"},
-                {"b202b370ef9768ec6561c4fe6b7e7296" +
-                        "fa85",
-                        "9c2159058b1f0fe91433a5bdc20e214e" +
-                                "ab7fecef4454a10ef0657df21ac7",
-                        "b18853f68d833640e42a3c02c25b6486" +
-                                "9e146d7b233987bddfc240871d7576f7",
-                        "028ec6eb5ea7e298342a94d4",
-                        "857e16a64915a787637687db4a951963" +
-                                "5cdd454fc2a154fea91f8363a39fec7d" +
-                                "0a49"},
-                {"ced532ce4159b035277d4dfbb7db6296" +
-                        "8b13cd4eec",
-                        "734320ccc9d9bbbb19cb81b2af4ecbc3" +
-                                "e72834321f7aa0f70b7282b4f33df23f" +
-                                "167541",
-                        "3c535de192eaed3822a2fbbe2ca9dfc8" +
-                                "8255e14a661b8aa82cc54236093bbc23",
-                        "688089e55540db1872504e1c",
-                        "626660c26ea6612fb17ad91e8e767639" +
-                                "edd6c9faee9d6c7029675b89eaf4ba1d" +
-                                "ed1a286594"}
-        };
+        for (String[] test : TESTS_KAT_256) {
+            byte[] plaintext = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] expected = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            assertArrayEquals(expected, ciphertext);
+            byte[] ciphertext = new AESGCMSIV(key).encrypt(nonce, plaintext, aad);
+            Assert.assertArrayEquals(expected, ciphertext);
         }
     }
 
     @Test
-    public void katDecrypt256() {
-        String[][] tests = {
-                {"", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07f5f4169bbf55a8400cd47ea6fd400f"},
-                {"0100000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2ef328e5c71c83b843122130f7364b7" +
-                                "61e0b97427e3df28"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "9aab2aeb3faa0a34aea8e2b18ca50da9" +
-                                "ae6559e48fd10f6e5c9ca17e"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "85a01b63025ba19b7fd3ddfc033b3e76" +
-                                "c9eac6fa700942702e90862383c6c366"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "4a6a9db4c8c6549201b9edb53006cba8" +
-                                "21ec9cf850948a7c86c68ac7539d027f" +
-                                "e819e63abcd020b006a976397632eb5d"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c00d121893a9fa603f48ccc1ca3c57ce" +
-                                "7499245ea0046db16c53c7c66fe717e3" +
-                                "9cf6c748837b61f6ee3adcee17534ed5" +
-                                "790bc96880a99ba804bd12c0e6a22cc4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2d5160a1f8683834910acdafc41fbb1" +
-                                "632d4a353e8b905ec9a5499ac34f96c7" +
-                                "e1049eb080883891a4db8caaa1f99dd0" +
-                                "04d80487540735234e3744512c6f90ce" +
-                                "112864c269fc0d9d88c61fa47e39aa08"},
-                {"0200000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1de22967237a813291213f267e3b452f" +
-                                "02d01ae33e4ec854"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "163d6f9cc1b346cd453a2e4cc1a4a19a" +
-                                "e800941ccdc57cc8413c277f"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c91545823cc24f17dbb0e9e807d5ec17" +
-                                "b292d28ff61189e8e49f3875ef91aff7"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07dad364bfc2b9da89116d7bef6daaaf" +
-                                "6f255510aa654f920ac81b94e8bad365" +
-                                "aea1bad12702e1965604374aab96dbbc"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c67a1f0f567a5198aa1fcc8e3f213143" +
-                                "36f7f51ca8b1af61feac35a86416fa47" +
-                                "fbca3b5f749cdf564527f2314f42fe25" +
-                                "03332742b228c647173616cfd44c54eb"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "67fd45e126bfb9a79930c43aad2d3696" +
-                                "7d3f0e4d217c1e551f59727870beefc9" +
-                                "8cb933a8fce9de887b1e40799988db1f" +
-                                "c3f91880ed405b2dd298318858467c89" +
-                                "5bde0285037c5de81e5b570a049b62a0"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "22b3f4cd1835e517741dfddccfa07fa4" +
-                                "661b74cf"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "43dd0163cdb48f9fe3212bf61b201976" +
-                                "067f342bb879ad976d8242acc188ab59" +
-                                "cabfe307"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "462401724b5ce6588d5a54aae5375513" +
-                                "a075cfcdf5042112aa29685c912fc205" +
-                                "6543"},
-                {"", "",
-                        "e66021d5eb8e4f4066d4adb9c33560e4" +
-                                "f46e44bb3da0015c94f7088736864200",
-                        "e0eaf5284d884a0e77d31646",
-                        "169fbb2fbf389a995f6390af22228a62"},
-                {"671fdd", "4fbdc66f14",
-                        "bae8e37fc83441b16034566b7a806c46" +
-                                "bb91c3c5aedb64a6c590bc84d1a5e269",
-                        "e4b47801afc0577e34699b9e",
-                        "0eaccb93da9bb81333aee0c785b240d3" +
-                                "19719d"},
-                {"195495860f04", "6787f3ea22c127aaf195",
-                        "6545fc880c94a95198874296d5cc1fd1" +
-                                "61320b6920ce07787f86743b275d1ab3",
-                        "2f6d1f0434d8848c1177441f",
-                        "a254dad4f3f96b62b84dc40c84636a5e" +
-                                "c12020ec8c2c"},
-                {"c9882e5386fd9f92ec", "489c8fde2be2cf97e74e932d4ed87d",
-                        "d1894728b3fed1473c528b8426a58299" +
-                                "5929a1499e9ad8780c8d63d0ab4149c0",
-                        "9f572c614b4745914474e7c7",
-                        "0df9e308678244c44bc0fd3dc6628dfe" +
-                                "55ebb0b9fb2295c8c2"},
-                {"1db2316fd568378da107b52b",
-                        "0da55210cc1c1b0abde3b2f204d1e9f8" +
-                                "b06bc47f",
-                        "a44102952ef94b02b805249bac80e6f6" +
-                                "1455bfac8308a2d40d8c845117808235",
-                        "5c9e940fea2f582950a70d5a",
-                        "8dbeb9f7255bf5769dd56692404099c2" +
-                                "587f64979f21826706d497d5"},
-                {"21702de0de18baa9c9596291b08466",
-                        "f37de21c7ff901cfe8a69615a93fdf7a" +
-                                "98cad481796245709f",
-                        "9745b3d1ae06556fb6aa7890bebc18fe" +
-                                "6b3db4da3d57aa94842b9803a96e07fb",
-                        "6de71860f762ebfbd08284e4",
-                        "793576dfa5c0f88729a7ed3c2f1bffb3" +
-                                "080d28f6ebb5d3648ce97bd5ba67fd"},
-                {"b202b370ef9768ec6561c4fe6b7e7296" +
-                        "fa85",
-                        "9c2159058b1f0fe91433a5bdc20e214e" +
-                                "ab7fecef4454a10ef0657df21ac7",
-                        "b18853f68d833640e42a3c02c25b6486" +
-                                "9e146d7b233987bddfc240871d7576f7",
-                        "028ec6eb5ea7e298342a94d4",
-                        "857e16a64915a787637687db4a951963" +
-                                "5cdd454fc2a154fea91f8363a39fec7d" +
-                                "0a49"},
-                {"ced532ce4159b035277d4dfbb7db6296" +
-                        "8b13cd4eec",
-                        "734320ccc9d9bbbb19cb81b2af4ecbc3" +
-                                "e72834321f7aa0f70b7282b4f33df23f" +
-                                "167541",
-                        "3c535de192eaed3822a2fbbe2ca9dfc8" +
-                                "8255e14a661b8aa82cc54236093bbc23",
-                        "688089e55540db1872504e1c",
-                        "626660c26ea6612fb17ad91e8e767639" +
-                                "edd6c9faee9d6c7029675b89eaf4ba1d" +
-                                "ed1a286594"}
-        };
+    public void katDecrypt256() throws AEADBadTagException {
+        for (String[] test : TESTS_KAT_256) {
+            byte[] expected = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] ciphertext = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-            byte[] decrypttext;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            assertArrayEquals(expected, ciphertext);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                assertArrayEquals(plaintext, decrypttext);
-            } catch (AEADBadTagException e) {
-                fail("");
-            }
+            byte[] decrypttext = new AESGCMSIV(key).decrypt(nonce, ciphertext, aad);
+            Assert.assertArrayEquals(expected, decrypttext);
         }
     }
 
     @Test
     public void wrapEncrypt() {
-        String[][] tests = {
-                {"00000000000000000000000000000000" +
-                        "4db923dc793ee6497c76dcc03a98e108",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "f3f80f2cf0cb2dd9c5984fcda908456c" +
-                                "c537703b5ba70324a6793a7bf218d3ea" +
-                                "ffffffff000000000000000000000000"},
-                {"eb3640277c7ffd1303c7a542d02d3e4c" +
-                        "0000000000000000",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "18ce4f0b8cb4d0cac65fea8f79257b20" +
-                                "888e53e72299e56dffffffff00000000" +
-                                "0000000000000000"}
-        };
+        for (String[] test : TESTS_KAT_WRAP) {
+            byte[] plaintext = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] expected = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            assertArrayEquals(expected, ciphertext);
+            byte[] ciphertext = new AESGCMSIV(key).encrypt(nonce, plaintext, aad);
+            Assert.assertArrayEquals(expected, ciphertext);
         }
     }
 
     @Test
-    public void wrapDecrypt() {
-        String[][] tests = {
-                {"00000000000000000000000000000000" +
-                        "4db923dc793ee6497c76dcc03a98e108",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "f3f80f2cf0cb2dd9c5984fcda908456c" +
-                                "c537703b5ba70324a6793a7bf218d3ea" +
-                                "ffffffff000000000000000000000000"},
-                {"eb3640277c7ffd1303c7a542d02d3e4c" +
-                        "0000000000000000",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "18ce4f0b8cb4d0cac65fea8f79257b20" +
-                                "888e53e72299e56dffffffff00000000" +
-                                "0000000000000000"}
-        };
+    public void wrapDecrypt() throws AEADBadTagException {
+        for (String[] test : TESTS_KAT_WRAP) {
+            byte[] expected = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] ciphertext = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] decrypttext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            assertArrayEquals(expected, ciphertext);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                assertArrayEquals(plaintext, decrypttext);
-            } catch (AEADBadTagException e) {
-                fail("");
-            }
+            byte[] decrypttext = new AESGCMSIV(key).decrypt(nonce, ciphertext, aad);
+            Assert.assertArrayEquals(expected, decrypttext);
         }
-    }
-
-    private static byte[] fromHex(String hex) {
-        byte[] result;
-        int hi, lo;
-        int hex_sz = hex.length();
-
-        result = new byte[hex_sz / 2];
-
-        for (int i = 0; i < hex_sz; i += 2) {
-            hi = Character.digit(hex.charAt(i), 16);
-            lo = Character.digit(hex.charAt(i + 1), 16);
-
-            result[i / 2] = (byte) ((hi << 4) + lo);
-        }
-
-        return result;
     }
 }

--- a/android/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
+++ b/android/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
@@ -20,41 +20,46 @@ import javax.crypto.AEADBadTagException;
 
 public final class AESGCMSIV {
     /**
-     * Size for AES-GCM-SIV nonce
+     * Size of an AES-GCM-SIV nonce.
      */
     public static final int NONCE_SIZE = 12;
+    /**
+     * Size of an AES-GCM-SIV tag.
+     */
     public static final int TAG_SIZE = 16;
 
-    /**
-     * Load the shared library
-     */
     static {
         System.loadLibrary("aesgcmsiv_jni");
     }
 
     /**
-     * Pointer to native AES-GCM-SIV context
+     * Pointer to the native AES-GCM-SIV context
      */
-    private long aes_gcmsiv_ctx;
+    private long aesGcmSivContext;
 
     /**
      * Create a AES-GCM-SIV cipher for a specified key.
      *
-     * @param key the AES key, whose length can be 128 or 256 bits (16 or 32 bytes respectively).
-     *            AES-GCM-SIV does not support AES with a key of 192 bits.
-     * @throws IllegalArgumentException if the input parameter does not have a valid size
+     * @param key the AES key, whose length can be 128 or 256-bit long (16 or 32 bytes respectively).
+     *            AES-GCM-SIV does not support 192-bit keys.
+     * @throws IllegalArgumentException if the input key does not have a valid size.
      */
     public AESGCMSIV(byte[] key) throws IllegalArgumentException {
-        aes_gcmsiv_ctx = 0;
-        init(key);
+        aesGcmSivContext = initNative(key);
     }
 
+    @Override
     public void finalize() {
-        free();
+        try {
+            freeNative(aesGcmSivContext);
+        } finally {
+            // Set context to null, even when freeNative fails
+            aesGcmSivContext = 0;
+        }
     }
 
     /**
-     * Encrypt plaintext, and authenticate this plaintext and additional data.
+     * Encrypt plaintext, and authenticate this plaintext and the additional data.
      *
      * @param nonce          the random (but not secret) nonce to use for this encryption.
      *                       It must be 96-bit long (12 bytes).
@@ -65,11 +70,13 @@ public final class AESGCMSIV {
      *                       It can be null or empty if there is no additional data to authenticate.
      *                       Maximum size is 2^36 bytes.
      * @return the ciphertext of the plaintext, which embed as well the authentication tag for the plaintext and the additional data.
-     *         It does not embed the nonce or additional data if any.
-     * @throws IllegalArgumentException if any of the input parameters don't have a valid size
+     * It does not embed the nonce or additional data if any.
+     * @throws IllegalArgumentException if any of the nonce, plaintext or additionalData does not have a valid size.
      */
-    public native byte[] encrypt(byte[] nonce, byte[] plaintext, byte[] additionalData)
-            throws IllegalArgumentException;
+    public byte[] encrypt(byte[] nonce, byte[] plaintext, byte[] additionalData)
+            throws IllegalArgumentException {
+        return encryptNative(aesGcmSivContext, nonce, plaintext, additionalData);
+    }
 
     /**
      * @param nonce          the random (but not secret) nonce used during the encryption.
@@ -79,15 +86,23 @@ public final class AESGCMSIV {
      * @param additionalData the additional data that was authenticated during encryption.
      *                       It can be null or empty if there was no additional data authenticated.
      * @return the plaintext corresponding to the ciphertext provided.
-     *         It can be an empty array if no data was encrypted, but only additional data were authenticated.
-     * @throws IllegalArgumentException if any of the input parameters don't have a valid size
-     * @throws AEADBadTagException      if the embedded authentication tag in the ciphertext does not match the
-     *                                  authentication tag of the plaintext and the additional data
+     * It can be an empty array if no data was encrypted, but only additional data were authenticated.
+     * @throws IllegalArgumentException if any of the nonce, ciphertext or additionalData does not have a valid size.
+     * @throws AEADBadTagException      if the embedded authentication tag in the ciphertext does not match the calculated
+     *                                  authentication tag of the plaintext and the additional data.
      */
-    public native byte[] decrypt(byte[] nonce, byte[] ciphertext, byte[] additionalData)
+    public byte[] decrypt(byte[] nonce, byte[] ciphertext, byte[] additionalData)
+            throws IllegalArgumentException, AEADBadTagException {
+        return decryptNative(aesGcmSivContext, nonce, ciphertext, additionalData);
+    }
+
+    private native long initNative(byte[] key) throws IllegalArgumentException;
+
+    private native void freeNative(long aesGcmSivContext);
+
+    private native byte[] encryptNative(long aesGcmSivContext, byte[] nonce, byte[] plaintext, byte[] additionalData)
+            throws IllegalArgumentException;
+
+    private native byte[] decryptNative(long aesGcmSivContext, byte[] nonce, byte[] ciphertext, byte[] additionalData)
             throws IllegalArgumentException, AEADBadTagException;
-
-    private native void init(byte[] key) throws IllegalArgumentException;
-
-    private native void free();
 }

--- a/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
+++ b/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/AESGCMSIV.java
@@ -16,21 +16,20 @@
 
 package com.linecorp.aesgcmsiv;
 
+import javax.crypto.AEADBadTagException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.crypto.AEADBadTagException;
-
 public final class AESGCMSIV {
     /**
-     * Size for AES-GCM-SIV nonce
+     * Size of an AES-GCM-SIV nonce.
      */
     public static final int NONCE_SIZE = 12;
+    /**
+     * Size of an AES-GCM-SIV tag.
+     */
     public static final int TAG_SIZE = 16;
 
-    /**
-     * Load the shared library
-     */
     static {
         try {
             ResourceLoader.loadLibraryFromJar("aesgcmsiv_jni");
@@ -40,29 +39,33 @@ public final class AESGCMSIV {
     }
 
     /**
-     * Pointer to native AES-GCM-SIV context
+     * Pointer to the native AES-GCM-SIV context
      */
-    private long aes_gcmsiv_ctx;
+    private long aesGcmSivContext;
 
     /**
      * Create a AES-GCM-SIV cipher for a specified key.
      *
-     * @param key the AES key, whose length can be 128 or 256 bits (16 or 32 bytes respectively).
-     *            AES-GCM-SIV does not support AES with a key of 192 bits.
-     * @throws IllegalArgumentException if the input parameter does not have a valid size
+     * @param key the AES key, whose length can be 128 or 256-bit long (16 or 32 bytes respectively).
+     *            AES-GCM-SIV does not support 192-bit keys.
+     * @throws IllegalArgumentException if the input key does not have a valid size.
      */
     public AESGCMSIV(byte[] key) throws IllegalArgumentException {
-        aes_gcmsiv_ctx = 0;
-        init(key);
+        aesGcmSivContext = initNative(key);
     }
 
     @Override
     protected void finalize() {
-        free();
+        try {
+            freeNative(aesGcmSivContext);
+        } finally {
+            // Set context to null, even when freeNative fails
+            aesGcmSivContext = 0;
+        }
     }
 
     /**
-     * Encrypt plaintext, and authenticate this plaintext and additional data.
+     * Encrypt plaintext, and authenticate this plaintext and the additional data.
      *
      * @param nonce          the random (but not secret) nonce to use for this encryption.
      *                       It must be 96-bit long (12 bytes).
@@ -73,11 +76,13 @@ public final class AESGCMSIV {
      *                       It can be null or empty if there is no additional data to authenticate.
      *                       Maximum size is 2^36 bytes.
      * @return the ciphertext of the plaintext, which embed as well the authentication tag for the plaintext and the additional data.
-     *         It does not embed the nonce or additional data if any.
-     * @throws IllegalArgumentException if any of the input parameters don't have a valid size
+     * It does not embed the nonce or additional data if any.
+     * @throws IllegalArgumentException if any of the nonce, plaintext or additionalData does not have a valid size.
      */
-    public native byte[] encrypt(byte[] nonce, byte[] plaintext, byte[] additionalData)
-            throws IllegalArgumentException;
+    public byte[] encrypt(byte[] nonce, byte[] plaintext, byte[] additionalData)
+            throws IllegalArgumentException {
+        return encryptNative(aesGcmSivContext, nonce, plaintext, additionalData);
+    }
 
     /**
      * @param nonce          the random (but not secret) nonce used during the encryption.
@@ -87,15 +92,23 @@ public final class AESGCMSIV {
      * @param additionalData the additional data that was authenticated during encryption.
      *                       It can be null or empty if there was no additional data authenticated.
      * @return the plaintext corresponding to the ciphertext provided.
-     *         It can be an empty array if no data was encrypted, but only additional data were authenticated.
-     * @throws IllegalArgumentException if any of the input parameters don't have a valid size
-     * @throws AEADBadTagException      if the embedded authentication tag in the ciphertext does not match the
-     *                                  authentication tag of the plaintext and the additional data
+     * It can be an empty array if no data was encrypted, but only additional data were authenticated.
+     * @throws IllegalArgumentException if any of the nonce, ciphertext or additionalData does not have a valid size.
+     * @throws AEADBadTagException      if the embedded authentication tag in the ciphertext does not match the calculated
+     *                                  authentication tag of the plaintext and the additional data.
      */
-    public native byte[] decrypt(byte[] nonce, byte[] ciphertext, byte[] additionalData)
+    public byte[] decrypt(byte[] nonce, byte[] ciphertext, byte[] additionalData)
+            throws IllegalArgumentException, AEADBadTagException {
+        return decryptNative(aesGcmSivContext, nonce, ciphertext, additionalData);
+    }
+
+    private native long initNative(byte[] key) throws IllegalArgumentException;
+
+    private native void freeNative(long aesGcmSivContext);
+
+    private native byte[] encryptNative(long aesGcmSivContext, byte[] nonce, byte[] plaintext, byte[] additionalData)
+            throws IllegalArgumentException;
+
+    private native byte[] decryptNative(long aesGcmSivContext, byte[] nonce, byte[] ciphertext, byte[] additionalData)
             throws IllegalArgumentException, AEADBadTagException;
-
-    private native void init(byte[] key) throws IllegalArgumentException;
-
-    private native void free();
 }

--- a/java/aesgcmsiv/src/test/java/com/linecorp/aesgcmsiv/AESGCMSIVTest.java
+++ b/java/aesgcmsiv/src/test/java/com/linecorp/aesgcmsiv/AESGCMSIVTest.java
@@ -20,1480 +20,438 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.crypto.AEADBadTagException;
-import java.util.Arrays;
+import java.lang.reflect.Field;
 
 public class AESGCMSIVTest {
+    private static final String[][] TESTS_KAT_128 = {
+            {"", "", "01000000000000000000000000000000", "030000000000000000000000", "dc20e2d83f25705bb49e439eca56de25"},
+            {"0100000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "b5d839330ac7b786578782fff6013b815b287c22493a364c"},
+            {"010000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "7323ea61d05932260047d942a4978db357391a0bc4fdec8b0d106639"},
+            {"01000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "743f7c8077ab25f8624e2e948579cf77303aaf90f6fe21199c6068577437a0c4"},
+            {"0100000000000000000000000000000002000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "84e07e62ba83a6585417245d7ec413a9fe427d6315c09b57ce45f2e3936a94451a8e45dcd4578c667cd86847bf6155ff"},
+            {"010000000000000000000000000000000200000000000000000000000000000003000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "3fd24ce1f5a67b75bf2351f181a475c7b800a5b4d3dcf70106b1eea82fa1d64df42bf7226122fa92e17a40eeaac1201b5e6e311dbf395d35b0fe39c2714388f8"},
+            {"01000000000000000000000000000000020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "", "01000000000000000000000000000000", "030000000000000000000000", "2433668f1058190f6d43e360f4f35cd8e475127cfca7028ea8ab5c20f7ab2af02516a2bdcbc08d521be37ff28c152bba36697f25b4cd169c6590d1dd39566d3f8a263dd317aa88d56bdf3936dba75bb8"},
+            {"0200000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "1e6daba35669f4273b0a1a2560969cdf790d99759abd1508"},
+            {"020000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "296c7889fd99f41917f4462008299c5102745aaa3a0c469fad9e075a"},
+            {"02000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "e2b0c5da79a901c1745f700525cb335b8f8936ec039e4e4bb97ebd8c4457441f"},
+            {"0200000000000000000000000000000003000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "620048ef3c1e73e57e02bb8562c416a319e73e4caac8e96a1ecb2933145a1d71e6af6a7f87287da059a71684ed3498e1"},
+            {"020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "50c8303ea93925d64090d07bd109dfd9515a5a33431019c17d93465999a8b0053201d723120a8562b838cdff25bf9d1e6a8cc3865f76897c2e4b245cf31c51f2"},
+            {"02000000000000000000000000000000030000000000000000000000000000000400000000000000000000000000000005000000000000000000000000000000", "01", "01000000000000000000000000000000", "030000000000000000000000", "2f5c64059db55ee0fb847ed513003746aca4e61c711b5de2e7a77ffd02da42feec601910d3467bb8b36ebbaebce5fba30d36c95f48a3e7980f0e7ac299332a80cdc46ae475563de037001ef84ae21744"},
+            {"02000000", "010000000000000000000000", "01000000000000000000000000000000", "030000000000000000000000", "a8fe3e8707eb1f84fb28f8cb73de8e99e2f48a14"},
+            {"0300000000000000000000000000000004000000", "010000000000000000000000000000000200", "01000000000000000000000000000000", "030000000000000000000000", "6bb0fecf5ded9b77f902c7d5da236a4391dd029724afc9805e976f451e6d87f6fe106514"},
+            {"030000000000000000000000000000000400", "0100000000000000000000000000000002000000", "01000000000000000000000000000000", "030000000000000000000000", "44d0aaf6fb2f1f34add5e8064e83e12a2adabff9b2ef00fb47920cc72a0c0f13b9fd"},
+            {"", "", "e66021d5eb8e4f4066d4adb9c33560e4", "f46e44bb3da0015c94f70887", "a4194b79071b01a87d65f706e3949578"},
+            {"7a806c", "46bb91c3c5", "36864200e0eaf5284d884a0e77d31646", "bae8e37fc83441b16034566b", "af60eb711bd85bc1e4d3e0a462e074eea428a8"},
+            {"bdc66f146545", "fc880c94a95198874296", "aedb64a6c590bc84d1a5e269e4b47801", "afc0577e34699b9e671fdd4f", "bb93a3e34d3cd6a9c45545cfc11f03ad743dba20f966"},
+            {"1177441f195495860f", "046787f3ea22c127aaf195d1894728", "d5cc1fd161320b6920ce07787f86743b", "275d1ab32f6d1f0434d8848c", "4f37281f7ad12949d01d02fd0cd174c84fc5dae2f60f52fd2b"},
+            {"9f572c614b4745914474e7c7", "c9882e5386fd9f92ec489c8fde2be2cf97e74e93", "b3fed1473c528b8426a582995929a149", "9e9ad8780c8d63d0ab4149c0", "f54673c5ddf710c745641c8bc1dc2f871fb7561da1286e655e24b7b0"},
+            {"0d8c8451178082355c9e940fea2f58", "2950a70d5a1db2316fd568378da107b52b0da55210cc1c1b0a", "2d4ed87da44102952ef94b02b805249b", "ac80e6f61455bfac8308a2d4", "c9ff545e07b88a015f05b274540aa183b3449b9f39552de99dc214a1190b0b"},
+            {"6b3db4da3d57aa94842b9803a96e07fb6de7", "1860f762ebfbd08284e421702de0de18baa9c9596291b08466f37de21c7f", "bde3b2f204d1e9f8b06bc47f9745b3d1", "ae06556fb6aa7890bebc18fe", "6298b296e24e8cc35dce0bed484b7f30d5803e377094f04709f64d7b985310a4db84"},
+            {"e42a3c02c25b64869e146d7b233987bddfc240871d", "7576f7028ec6eb5ea7e298342a94d4b202b370ef9768ec6561c4fe6b7e7296fa859c21", "f901cfe8a69615a93fdf7a98cad48179", "6245709fb18853f68d833640", "391cc328d484a4f46406181bcd62efd9b3ee197d052d15506c84a9edd65e13e9d24a2a6e70"}
+    };
+
+    private static final String[][] TESTS_KAT_256 = {
+            {"", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "07f5f4169bbf55a8400cd47ea6fd400f"},
+            {"0100000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c2ef328e5c71c83b843122130f7364b761e0b97427e3df28"},
+            {"010000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "9aab2aeb3faa0a34aea8e2b18ca50da9ae6559e48fd10f6e5c9ca17e"},
+            {"01000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "85a01b63025ba19b7fd3ddfc033b3e76c9eac6fa700942702e90862383c6c366"},
+            {"0100000000000000000000000000000002000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "4a6a9db4c8c6549201b9edb53006cba821ec9cf850948a7c86c68ac7539d027fe819e63abcd020b006a976397632eb5d"},
+            {"010000000000000000000000000000000200000000000000000000000000000003000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c00d121893a9fa603f48ccc1ca3c57ce7499245ea0046db16c53c7c66fe717e39cf6c748837b61f6ee3adcee17534ed5790bc96880a99ba804bd12c0e6a22cc4"},
+            {"01000000000000000000000000000000020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c2d5160a1f8683834910acdafc41fbb1632d4a353e8b905ec9a5499ac34f96c7e1049eb080883891a4db8caaa1f99dd004d80487540735234e3744512c6f90ce112864c269fc0d9d88c61fa47e39aa08"},
+            {"0200000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "1de22967237a813291213f267e3b452f02d01ae33e4ec854"},
+            {"020000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "163d6f9cc1b346cd453a2e4cc1a4a19ae800941ccdc57cc8413c277f"},
+            {"02000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c91545823cc24f17dbb0e9e807d5ec17b292d28ff61189e8e49f3875ef91aff7"},
+            {"0200000000000000000000000000000003000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "07dad364bfc2b9da89116d7bef6daaaf6f255510aa654f920ac81b94e8bad365aea1bad12702e1965604374aab96dbbc"},
+            {"020000000000000000000000000000000300000000000000000000000000000004000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "c67a1f0f567a5198aa1fcc8e3f21314336f7f51ca8b1af61feac35a86416fa47fbca3b5f749cdf564527f2314f42fe2503332742b228c647173616cfd44c54eb"},
+            {"02000000000000000000000000000000030000000000000000000000000000000400000000000000000000000000000005000000000000000000000000000000", "01", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "67fd45e126bfb9a79930c43aad2d36967d3f0e4d217c1e551f59727870beefc98cb933a8fce9de887b1e40799988db1fc3f91880ed405b2dd298318858467c895bde0285037c5de81e5b570a049b62a0"},
+            {"02000000", "010000000000000000000000", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "22b3f4cd1835e517741dfddccfa07fa4661b74cf"},
+            {"0300000000000000000000000000000004000000", "010000000000000000000000000000000200", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "43dd0163cdb48f9fe3212bf61b201976067f342bb879ad976d8242acc188ab59cabfe307"},
+            {"030000000000000000000000000000000400", "0100000000000000000000000000000002000000", "0100000000000000000000000000000000000000000000000000000000000000", "030000000000000000000000", "462401724b5ce6588d5a54aae5375513a075cfcdf5042112aa29685c912fc2056543"},
+            {"", "", "e66021d5eb8e4f4066d4adb9c33560e4f46e44bb3da0015c94f7088736864200", "e0eaf5284d884a0e77d31646", "169fbb2fbf389a995f6390af22228a62"},
+            {"671fdd", "4fbdc66f14", "bae8e37fc83441b16034566b7a806c46bb91c3c5aedb64a6c590bc84d1a5e269", "e4b47801afc0577e34699b9e", "0eaccb93da9bb81333aee0c785b240d319719d"},
+            {"195495860f04", "6787f3ea22c127aaf195", "6545fc880c94a95198874296d5cc1fd161320b6920ce07787f86743b275d1ab3", "2f6d1f0434d8848c1177441f", "a254dad4f3f96b62b84dc40c84636a5ec12020ec8c2c"},
+            {"c9882e5386fd9f92ec", "489c8fde2be2cf97e74e932d4ed87d", "d1894728b3fed1473c528b8426a582995929a1499e9ad8780c8d63d0ab4149c0", "9f572c614b4745914474e7c7", "0df9e308678244c44bc0fd3dc6628dfe55ebb0b9fb2295c8c2"},
+            {"1db2316fd568378da107b52b", "0da55210cc1c1b0abde3b2f204d1e9f8b06bc47f", "a44102952ef94b02b805249bac80e6f61455bfac8308a2d40d8c845117808235", "5c9e940fea2f582950a70d5a", "8dbeb9f7255bf5769dd56692404099c2587f64979f21826706d497d5"},
+            {"21702de0de18baa9c9596291b08466", "f37de21c7ff901cfe8a69615a93fdf7a98cad481796245709f", "9745b3d1ae06556fb6aa7890bebc18fe6b3db4da3d57aa94842b9803a96e07fb", "6de71860f762ebfbd08284e4", "793576dfa5c0f88729a7ed3c2f1bffb3080d28f6ebb5d3648ce97bd5ba67fd"},
+            {"b202b370ef9768ec6561c4fe6b7e7296fa85", "9c2159058b1f0fe91433a5bdc20e214eab7fecef4454a10ef0657df21ac7", "b18853f68d833640e42a3c02c25b64869e146d7b233987bddfc240871d7576f7", "028ec6eb5ea7e298342a94d4", "857e16a64915a787637687db4a9519635cdd454fc2a154fea91f8363a39fec7d0a49"},
+            {"ced532ce4159b035277d4dfbb7db62968b13cd4eec", "734320ccc9d9bbbb19cb81b2af4ecbc3e72834321f7aa0f70b7282b4f33df23f167541", "3c535de192eaed3822a2fbbe2ca9dfc88255e14a661b8aa82cc54236093bbc23", "688089e55540db1872504e1c", "626660c26ea6612fb17ad91e8e767639edd6c9faee9d6c7029675b89eaf4ba1ded1a286594"}
+    };
+
+    private static final String[][] TESTS_KAT_WRAP = {
+            {"000000000000000000000000000000004db923dc793ee6497c76dcc03a98e108", "", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000", "f3f80f2cf0cb2dd9c5984fcda908456cc537703b5ba70324a6793a7bf218d3eaffffffff000000000000000000000000"},
+            {"eb3640277c7ffd1303c7a542d02d3e4c0000000000000000", "", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000", "18ce4f0b8cb4d0cac65fea8f79257b20888e53e72299e56dffffffff000000000000000000000000"}
+    };
+
     private static byte[] fromHex(String hex) {
-        byte[] result;
-        int hi, lo;
-        int hex_sz = hex.length();
+        if ((hex.length() % 2) != 0) {
+            throw new IllegalArgumentException("Invalid hex string: " + hex);
+        }
 
-        result = new byte[hex_sz / 2];
+        byte[] result = new byte[hex.length() / 2];
 
-        for (int i = 0; i < hex_sz; i += 2) {
-            hi = Character.digit(hex.charAt(i), 16);
-            lo = Character.digit(hex.charAt(i + 1), 16);
-
-            result[i / 2] = (byte) ((hi << 4) + lo);
+        for (int i = 0; i < result.length; ++i) {
+            int hi = Character.digit(hex.charAt(2 * i), 16);
+            int lo = Character.digit(hex.charAt((2 * i) + 1), 16);
+            result[i] = (byte) ((hi << 4) + lo);
         }
 
         return result;
     }
 
     @Test
-    public void testSomeAESGCMSIVMethod() {
-        AESGCMSIV classUnderTest = new AESGCMSIV(new byte[16]);
-    }
-
-    @Test
     public void apiInit() {
         // Test with null key
-        {
-            try {
-                new AESGCMSIV(null);
-                Assert.fail();
-            } catch (Exception e) {
-                Assert.assertTrue(true);
-            }
+        try {
+            new AESGCMSIV(null);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid size for key
-        {
-            byte[] key = new byte[8];
-
-            try {
-                new AESGCMSIV(key);
-                Assert.fail();
-            } catch (Exception e) {
-                Assert.assertTrue(true);
-            }
+        try {
+            new AESGCMSIV(new byte[8]);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test when all goes well
-        {
-            byte[] key = new byte[16];
+        new AESGCMSIV(new byte[16]);
+    }
 
+    @Test
+    public void apiFinalize() throws NoSuchFieldException, IllegalAccessException {
+        // Make aesGcmSivContext field public for this test
+        Field aesGcmSivContext = AESGCMSIV.class.getDeclaredField("aesGcmSivContext");
+        aesGcmSivContext.setAccessible(true);
+
+        try {
+            AESGCMSIV ctx;
+
+            // Finalize on null context
             try {
-                new AESGCMSIV(key);
-            } catch (Exception e) {
+                AESGCMSIV tmp = null;
+                tmp.finalize();
                 Assert.fail();
+            } catch (NullPointerException ignored) {
             }
+
+            // Finalize on normal context
+            ctx = new AESGCMSIV(new byte[16]);
+            Assert.assertNotEquals(0, aesGcmSivContext.getLong(ctx));
+
+            ctx.finalize();
+            Assert.assertEquals(0, aesGcmSivContext.getLong(ctx));
+
+            // Finalize twice on normal context
+            ctx = new AESGCMSIV(new byte[16]);
+            Assert.assertNotEquals(0, aesGcmSivContext.getLong(ctx));
+
+            ctx.finalize();
+            Assert.assertEquals(0, aesGcmSivContext.getLong(ctx));
+            ctx.finalize();
+            Assert.assertEquals(0, aesGcmSivContext.getLong(ctx));
+        } finally {
+            aesGcmSivContext.setAccessible(false);
         }
     }
 
     @Test
     public void apiEncrypt() {
-        // Test with null ctx
-        {
-            AESGCMSIV ctx = null;
+        AESGCMSIV ctx = new AESGCMSIV(new byte[16]);
+        byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
+        byte[] aad = new byte[16];
+        byte[] plaintext = new byte[16];
+        byte[] ciphertext;
 
-            try {
-                ctx.encrypt(null, null, null);
-                Assert.fail();
-            } catch (NullPointerException e) {
-                Assert.assertTrue(true);
-            }
+        // Test with null ctx
+        try {
+            AESGCMSIV tmp = null;
+            tmp.encrypt(nonce, plaintext, aad);
+            Assert.fail();
+        } catch (NullPointerException ignored) {
         }
 
         // Test with null nonce
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.encrypt(null, null, null);
-                Assert.fail();
-            } catch (IllegalArgumentException e) {
-                Assert.assertTrue(true);
-            }
+        try {
+            ctx.encrypt(null, plaintext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid nonce size
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[8];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.encrypt(nonce, null, null);
-                Assert.fail();
-            } catch (IllegalArgumentException e) {
-                Assert.assertTrue(true);
-            }
+        try {
+            ctx.encrypt(new byte[8], plaintext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test when all goes well
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[10];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
+        ciphertext = ctx.encrypt(nonce, plaintext, aad);
+        Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-            ctx = new AESGCMSIV(key);
+        // Test when all goes well, but plaintext == null
+        ciphertext = ctx.encrypt(nonce, null, aad);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
+        // Test when all goes well, but plaintext size == 0
+        ciphertext = ctx.encrypt(nonce, new byte[0], aad);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-        // Test when all goes well, but nothing to encrypt (plaintext == null)
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
+        // Test when all goes well, but aad == null
+        ciphertext = ctx.encrypt(nonce, plaintext, null);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE + plaintext.length, ciphertext.length);
 
-            ctx = new AESGCMSIV(key);
+        // Test when all goes well, but aad size == 0
+        ciphertext = ctx.encrypt(nonce, plaintext, new byte[0]);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE + plaintext.length, ciphertext.length);
 
-            ciphertext = ctx.encrypt(nonce, null, aad);
-            Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
+        // Test when all goes well, but plaintext and aad == null
+        ciphertext = ctx.encrypt(nonce, null, null);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
 
-        // Test when all goes well, but nothing to encrypt (plaintext size is 0)
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[0];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            ctx = new AESGCMSIV(key);
-
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
-
-        // Test when all goes well, but no aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[0];
-            byte[] ciphertext;
-
-            ctx = new AESGCMSIV(key);
-
-            ciphertext = ctx.encrypt(nonce, plaintext, null);
-            Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
-
-        // Test when all goes well, but no plaintext nor aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-
-            ctx = new AESGCMSIV(key);
-
-            ciphertext = ctx.encrypt(nonce, null, null);
-            Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
-        }
+        // Test when all goes well, but plaintext and aad size == 0
+        ciphertext = ctx.encrypt(nonce, new byte[0], new byte[0]);
+        Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
     }
 
     @Test
-    public void apiDecrypt() {
-        // Test with null ctx
-        {
-            AESGCMSIV ctx = null;
+    public void apiDecrypt() throws AEADBadTagException {
+        AESGCMSIV ctx = new AESGCMSIV(new byte[16]);
+        byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
+        byte[] aad = new byte[16];
+        byte[] plaintext = new byte[16];
+        byte[] ciphertext = ctx.encrypt(nonce, plaintext, aad);
+        byte[] decrypttext;
 
-            try {
-                ctx.decrypt(null, null, null);
-                Assert.fail();
-            } catch (NullPointerException e) {
-                Assert.assertTrue(true);
-            } catch (AEADBadTagException e) {
-                Assert.fail();
-            }
+        // Test with null ctx
+        try {
+            AESGCMSIV tmp = null;
+            tmp.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (NullPointerException ignored) {
         }
 
         // Test with null nonce
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.decrypt(null, null, null);
-                Assert.fail();
-            } catch (IllegalArgumentException e) {
-                Assert.assertTrue(true);
-            } catch (AEADBadTagException e) {
-                Assert.fail();
-            }
+        try {
+            ctx.decrypt(null, ciphertext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid nonce size
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[8];
+        try {
+            ctx.decrypt(new byte[8], ciphertext, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
+        }
 
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.decrypt(nonce, null, null);
-                Assert.fail();
-            } catch (IllegalArgumentException e) {
-                Assert.assertTrue(true);
-            } catch (AEADBadTagException e) {
-                Assert.fail();
-            }
+        // Test with null ciphertext
+        try {
+            ctx.decrypt(nonce, null, aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test with invalid ciphertext size
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext = new byte[AESGCMSIV.TAG_SIZE - 1];
-
-            ctx = new AESGCMSIV(key);
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                Assert.fail();
-            } catch (IllegalArgumentException e) {
-                Assert.assertTrue(true);
-            } catch (AEADBadTagException e) {
-                Assert.fail();
-            }
+        try {
+            ctx.decrypt(nonce, new byte[AESGCMSIV.TAG_SIZE - 1], aad);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
         }
 
         // Test when all goes well
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-            byte[] decrypttext;
+        decrypttext = ctx.decrypt(nonce, ciphertext, aad);
+        Assert.assertArrayEquals(plaintext, decrypttext);
 
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
+        // Test when all goes well, but plaintext size == 0
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, null, aad), aad);
+        Assert.assertArrayEquals(new byte[0], decrypttext);
 
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                Assert.assertArrayEquals(plaintext, decrypttext);
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        }
+        // Test when all goes well, but aad == null
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, plaintext, null), null);
+        Assert.assertArrayEquals(plaintext, decrypttext);
 
-        // Test when all goes well , but nothing to decrypt
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-            byte[] decrypttext;
+        // Test when all goes well, but no plaintext and aad == null
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, null, null), null);
+        Assert.assertArrayEquals(new byte[0], decrypttext);
 
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, null, null);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, null);
-                Assert.assertArrayEquals(new byte[0], decrypttext);
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        }
-
-        // Test when all goes well , but no aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-            byte[] decrypttext;
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, null);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, null);
-                Assert.assertArrayEquals(plaintext, decrypttext);
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        }
-
-        // Test when all goes well, but no plaintext nor aad
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-            byte[] decrypttext;
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, null, null);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, null);
-                Assert.assertArrayEquals(new byte[0], decrypttext);
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        }
+        // Test when all goes well, but no plaintext and aad size == 0
+        decrypttext = ctx.decrypt(nonce, ctx.encrypt(nonce, null, new byte[0]), new byte[0]);
+        Assert.assertArrayEquals(new byte[0], decrypttext);
     }
 
     @Test
     public void badDecrypt() {
+        AESGCMSIV ctx = new AESGCMSIV(new byte[16]);
+        byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
+        byte[] aad = new byte[16];
+        byte[] plaintext = new byte[16];
+        byte[] ciphertext;
+
         // No plaintext, no AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, null, null);
-            Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // No plaintext, AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(aad, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, null, aad);
-            Assert.assertEquals(AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, no AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, null);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, no AAD, error on ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, null);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, no AAD, error both tag and ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, null);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, null);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, null);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, AAD, error on tag
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-            Arrays.fill(aad, (byte) 0x03);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, AAD, error on ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-            Arrays.fill(aad, (byte) 0x03);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
 
         // Plaintext, AAD, error on both tag and ciphertext
-        {
-            AESGCMSIV ctx;
-            byte[] key = new byte[16];
-            byte[] nonce = new byte[AESGCMSIV.NONCE_SIZE];
-            byte[] plaintext = new byte[16];
-            byte[] aad = new byte[16];
-            byte[] ciphertext;
-
-            Arrays.fill(key, (byte) 0x00);
-            Arrays.fill(nonce, (byte) 0x01);
-            Arrays.fill(plaintext, (byte) 0x02);
-            Arrays.fill(aad, (byte) 0x03);
-
-            ctx = new AESGCMSIV(key);
-
+        try {
             ciphertext = ctx.encrypt(nonce, plaintext, aad);
-            Assert.assertEquals(plaintext.length + AESGCMSIV.TAG_SIZE, ciphertext.length);
+            ciphertext[0] ^= (byte) 0xff;
+            ciphertext[16] ^= (byte) 0xff;
 
-            ciphertext[0] ^= 0xff;
-            ciphertext[16] ^= 0xff;
-
-            try {
-                ctx.decrypt(nonce, ciphertext, aad);
-                Assert.fail();
-            } catch (AEADBadTagException e) {
-                Assert.assertTrue(true);
-            }
+            ctx.decrypt(nonce, ciphertext, aad);
+            Assert.fail();
+        } catch (AEADBadTagException ignored) {
         }
     }
 
     @Test
     public void katEncrypt128() {
-        String[][] tests = {
-                {"", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "dc20e2d83f25705bb49e439eca56de25"},
-                {"0100000000000000", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "b5d839330ac7b786578782fff6013b81" +
-                                "5b287c22493a364c"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "7323ea61d05932260047d942a4978db3" +
-                                "57391a0bc4fdec8b0d106639"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "743f7c8077ab25f8624e2e948579cf77" +
-                                "303aaf90f6fe21199c6068577437a0c4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "84e07e62ba83a6585417245d7ec413a9" +
-                                "fe427d6315c09b57ce45f2e3936a9445" +
-                                "1a8e45dcd4578c667cd86847bf6155ff"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "3fd24ce1f5a67b75bf2351f181a475c7" +
-                                "b800a5b4d3dcf70106b1eea82fa1d64d" +
-                                "f42bf7226122fa92e17a40eeaac1201b" +
-                                "5e6e311dbf395d35b0fe39c2714388f8"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2433668f1058190f6d43e360f4f35cd8" +
-                                "e475127cfca7028ea8ab5c20f7ab2af0" +
-                                "2516a2bdcbc08d521be37ff28c152bba" +
-                                "36697f25b4cd169c6590d1dd39566d3f" +
-                                "8a263dd317aa88d56bdf3936dba75bb8"},
-                {"0200000000000000", "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1e6daba35669f4273b0a1a2560969cdf" +
-                                "790d99759abd1508"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "296c7889fd99f41917f4462008299c51" +
-                                "02745aaa3a0c469fad9e075a"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "e2b0c5da79a901c1745f700525cb335b" +
-                                "8f8936ec039e4e4bb97ebd8c4457441f"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "620048ef3c1e73e57e02bb8562c416a3" +
-                                "19e73e4caac8e96a1ecb2933145a1d71" +
-                                "e6af6a7f87287da059a71684ed3498e1"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "50c8303ea93925d64090d07bd109dfd9" +
-                                "515a5a33431019c17d93465999a8b005" +
-                                "3201d723120a8562b838cdff25bf9d1e" +
-                                "6a8cc3865f76897c2e4b245cf31c51f2"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2f5c64059db55ee0fb847ed513003746" +
-                                "aca4e61c711b5de2e7a77ffd02da42fe" +
-                                "ec601910d3467bb8b36ebbaebce5fba3" +
-                                "0d36c95f48a3e7980f0e7ac299332a80" +
-                                "cdc46ae475563de037001ef84ae21744"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "a8fe3e8707eb1f84fb28f8cb73de8e99" +
-                                "e2f48a14"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "6bb0fecf5ded9b77f902c7d5da236a43" +
-                                "91dd029724afc9805e976f451e6d87f6" +
-                                "fe106514"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "44d0aaf6fb2f1f34add5e8064e83e12a" +
-                                "2adabff9b2ef00fb47920cc72a0c0f13" +
-                                "b9fd"},
-                {"", "", "e66021d5eb8e4f4066d4adb9c33560e4",
-                        "f46e44bb3da0015c94f70887",
-                        "a4194b79071b01a87d65f706e3949578"},
-                {"7a806c", "46bb91c3c5", "36864200e0eaf5284d884a0e77d31646",
-                        "bae8e37fc83441b16034566b",
-                        "af60eb711bd85bc1e4d3e0a462e074ee" +
-                                "a428a8"},
-                {"bdc66f146545", "fc880c94a95198874296",
-                        "aedb64a6c590bc84d1a5e269e4b47801",
-                        "afc0577e34699b9e671fdd4f",
-                        "bb93a3e34d3cd6a9c45545cfc11f03ad" +
-                                "743dba20f966"},
-                {"1177441f195495860f", "046787f3ea22c127aaf195d1894728",
-                        "d5cc1fd161320b6920ce07787f86743b",
-                        "275d1ab32f6d1f0434d8848c",
-                        "4f37281f7ad12949d01d02fd0cd174c8" +
-                                "4fc5dae2f60f52fd2b"},
-                {"9f572c614b4745914474e7c7",
-                        "c9882e5386fd9f92ec489c8fde2be2cf" +
-                                "97e74e93",
-                        "b3fed1473c528b8426a582995929a149",
-                        "9e9ad8780c8d63d0ab4149c0",
-                        "f54673c5ddf710c745641c8bc1dc2f87" +
-                                "1fb7561da1286e655e24b7b0"},
-                {"0d8c8451178082355c9e940fea2f58",
-                        "2950a70d5a1db2316fd568378da107b5" +
-                                "2b0da55210cc1c1b0a",
-                        "2d4ed87da44102952ef94b02b805249b",
-                        "ac80e6f61455bfac8308a2d4",
-                        "c9ff545e07b88a015f05b274540aa183" +
-                                "b3449b9f39552de99dc214a1190b0b"},
-                {"6b3db4da3d57aa94842b9803a96e07fb" +
-                        "6de7",
-                        "1860f762ebfbd08284e421702de0de18" +
-                                "baa9c9596291b08466f37de21c7f",
-                        "bde3b2f204d1e9f8b06bc47f9745b3d1",
-                        "ae06556fb6aa7890bebc18fe",
-                        "6298b296e24e8cc35dce0bed484b7f30" +
-                                "d5803e377094f04709f64d7b985310a4" +
-                                "db84"},
-                {"e42a3c02c25b64869e146d7b233987bd" +
-                        "dfc240871d",
-                        "7576f7028ec6eb5ea7e298342a94d4b2" +
-                                "02b370ef9768ec6561c4fe6b7e7296fa" +
-                                "859c21",
-                        "f901cfe8a69615a93fdf7a98cad48179",
-                        "6245709fb18853f68d833640",
-                        "391cc328d484a4f46406181bcd62efd9" +
-                                "b3ee197d052d15506c84a9edd65e13e9" +
-                                "d24a2a6e70"}
-        };
+        for (String[] test : TESTS_KAT_128) {
+            byte[] plaintext = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] expected = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
+            byte[] ciphertext = new AESGCMSIV(key).encrypt(nonce, plaintext, aad);
             Assert.assertArrayEquals(expected, ciphertext);
         }
     }
 
     @Test
-    public void katDecrypt128() {
-        String[][] tests = {
-                {"", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "dc20e2d83f25705bb49e439eca56de25"},
-                {"0100000000000000", "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "b5d839330ac7b786578782fff6013b81" +
-                                "5b287c22493a364c"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "7323ea61d05932260047d942a4978db3" +
-                                "57391a0bc4fdec8b0d106639"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "743f7c8077ab25f8624e2e948579cf77" +
-                                "303aaf90f6fe21199c6068577437a0c4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "84e07e62ba83a6585417245d7ec413a9" +
-                                "fe427d6315c09b57ce45f2e3936a9445" +
-                                "1a8e45dcd4578c667cd86847bf6155ff"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "3fd24ce1f5a67b75bf2351f181a475c7" +
-                                "b800a5b4d3dcf70106b1eea82fa1d64d" +
-                                "f42bf7226122fa92e17a40eeaac1201b" +
-                                "5e6e311dbf395d35b0fe39c2714388f8"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2433668f1058190f6d43e360f4f35cd8" +
-                                "e475127cfca7028ea8ab5c20f7ab2af0" +
-                                "2516a2bdcbc08d521be37ff28c152bba" +
-                                "36697f25b4cd169c6590d1dd39566d3f" +
-                                "8a263dd317aa88d56bdf3936dba75bb8"},
-                {"0200000000000000", "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1e6daba35669f4273b0a1a2560969cdf" +
-                                "790d99759abd1508"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "296c7889fd99f41917f4462008299c51" +
-                                "02745aaa3a0c469fad9e075a"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "e2b0c5da79a901c1745f700525cb335b" +
-                                "8f8936ec039e4e4bb97ebd8c4457441f"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "620048ef3c1e73e57e02bb8562c416a3" +
-                                "19e73e4caac8e96a1ecb2933145a1d71" +
-                                "e6af6a7f87287da059a71684ed3498e1"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "50c8303ea93925d64090d07bd109dfd9" +
-                                "515a5a33431019c17d93465999a8b005" +
-                                "3201d723120a8562b838cdff25bf9d1e" +
-                                "6a8cc3865f76897c2e4b245cf31c51f2"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01", "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "2f5c64059db55ee0fb847ed513003746" +
-                                "aca4e61c711b5de2e7a77ffd02da42fe" +
-                                "ec601910d3467bb8b36ebbaebce5fba3" +
-                                "0d36c95f48a3e7980f0e7ac299332a80" +
-                                "cdc46ae475563de037001ef84ae21744"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "a8fe3e8707eb1f84fb28f8cb73de8e99" +
-                                "e2f48a14"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "6bb0fecf5ded9b77f902c7d5da236a43" +
-                                "91dd029724afc9805e976f451e6d87f6" +
-                                "fe106514"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "44d0aaf6fb2f1f34add5e8064e83e12a" +
-                                "2adabff9b2ef00fb47920cc72a0c0f13" +
-                                "b9fd"},
-                {"", "", "e66021d5eb8e4f4066d4adb9c33560e4",
-                        "f46e44bb3da0015c94f70887",
-                        "a4194b79071b01a87d65f706e3949578"},
-                {"7a806c", "46bb91c3c5", "36864200e0eaf5284d884a0e77d31646",
-                        "bae8e37fc83441b16034566b",
-                        "af60eb711bd85bc1e4d3e0a462e074ee" +
-                                "a428a8"},
-                {"bdc66f146545", "fc880c94a95198874296",
-                        "aedb64a6c590bc84d1a5e269e4b47801",
-                        "afc0577e34699b9e671fdd4f",
-                        "bb93a3e34d3cd6a9c45545cfc11f03ad" +
-                                "743dba20f966"},
-                {"1177441f195495860f", "046787f3ea22c127aaf195d1894728",
-                        "d5cc1fd161320b6920ce07787f86743b",
-                        "275d1ab32f6d1f0434d8848c",
-                        "4f37281f7ad12949d01d02fd0cd174c8" +
-                                "4fc5dae2f60f52fd2b"},
-                {"9f572c614b4745914474e7c7",
-                        "c9882e5386fd9f92ec489c8fde2be2cf" +
-                                "97e74e93",
-                        "b3fed1473c528b8426a582995929a149",
-                        "9e9ad8780c8d63d0ab4149c0",
-                        "f54673c5ddf710c745641c8bc1dc2f87" +
-                                "1fb7561da1286e655e24b7b0"},
-                {"0d8c8451178082355c9e940fea2f58",
-                        "2950a70d5a1db2316fd568378da107b5" +
-                                "2b0da55210cc1c1b0a",
-                        "2d4ed87da44102952ef94b02b805249b",
-                        "ac80e6f61455bfac8308a2d4",
-                        "c9ff545e07b88a015f05b274540aa183" +
-                                "b3449b9f39552de99dc214a1190b0b"},
-                {"6b3db4da3d57aa94842b9803a96e07fb" +
-                        "6de7",
-                        "1860f762ebfbd08284e421702de0de18" +
-                                "baa9c9596291b08466f37de21c7f",
-                        "bde3b2f204d1e9f8b06bc47f9745b3d1",
-                        "ae06556fb6aa7890bebc18fe",
-                        "6298b296e24e8cc35dce0bed484b7f30" +
-                                "d5803e377094f04709f64d7b985310a4" +
-                                "db84"},
-                {"e42a3c02c25b64869e146d7b233987bd" +
-                        "dfc240871d",
-                        "7576f7028ec6eb5ea7e298342a94d4b2" +
-                                "02b370ef9768ec6561c4fe6b7e7296fa" +
-                                "859c21",
-                        "f901cfe8a69615a93fdf7a98cad48179",
-                        "6245709fb18853f68d833640",
-                        "391cc328d484a4f46406181bcd62efd9" +
-                                "b3ee197d052d15506c84a9edd65e13e9" +
-                                "d24a2a6e70"}
-        };
+    public void katDecrypt128() throws AEADBadTagException {
+        for (String[] test : TESTS_KAT_128) {
+            byte[] expected = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] ciphertext = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] decrypttext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            Assert.assertArrayEquals(expected, ciphertext);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                Assert.assertArrayEquals(plaintext, decrypttext);
-            } catch (AEADBadTagException e) {
-                Assert.fail();
-            }
+            byte[] decrypttext = new AESGCMSIV(key).decrypt(nonce, ciphertext, aad);
+            Assert.assertArrayEquals(expected, decrypttext);
         }
     }
 
     @Test
     public void katEncrypt256() {
-        String[][] tests = {
-                {"", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07f5f4169bbf55a8400cd47ea6fd400f"},
-                {"0100000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2ef328e5c71c83b843122130f7364b7" +
-                                "61e0b97427e3df28"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "9aab2aeb3faa0a34aea8e2b18ca50da9" +
-                                "ae6559e48fd10f6e5c9ca17e"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "85a01b63025ba19b7fd3ddfc033b3e76" +
-                                "c9eac6fa700942702e90862383c6c366"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "4a6a9db4c8c6549201b9edb53006cba8" +
-                                "21ec9cf850948a7c86c68ac7539d027f" +
-                                "e819e63abcd020b006a976397632eb5d"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c00d121893a9fa603f48ccc1ca3c57ce" +
-                                "7499245ea0046db16c53c7c66fe717e3" +
-                                "9cf6c748837b61f6ee3adcee17534ed5" +
-                                "790bc96880a99ba804bd12c0e6a22cc4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2d5160a1f8683834910acdafc41fbb1" +
-                                "632d4a353e8b905ec9a5499ac34f96c7" +
-                                "e1049eb080883891a4db8caaa1f99dd0" +
-                                "04d80487540735234e3744512c6f90ce" +
-                                "112864c269fc0d9d88c61fa47e39aa08"},
-                {"0200000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1de22967237a813291213f267e3b452f" +
-                                "02d01ae33e4ec854"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "163d6f9cc1b346cd453a2e4cc1a4a19a" +
-                                "e800941ccdc57cc8413c277f"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c91545823cc24f17dbb0e9e807d5ec17" +
-                                "b292d28ff61189e8e49f3875ef91aff7"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07dad364bfc2b9da89116d7bef6daaaf" +
-                                "6f255510aa654f920ac81b94e8bad365" +
-                                "aea1bad12702e1965604374aab96dbbc"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c67a1f0f567a5198aa1fcc8e3f213143" +
-                                "36f7f51ca8b1af61feac35a86416fa47" +
-                                "fbca3b5f749cdf564527f2314f42fe25" +
-                                "03332742b228c647173616cfd44c54eb"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "67fd45e126bfb9a79930c43aad2d3696" +
-                                "7d3f0e4d217c1e551f59727870beefc9" +
-                                "8cb933a8fce9de887b1e40799988db1f" +
-                                "c3f91880ed405b2dd298318858467c89" +
-                                "5bde0285037c5de81e5b570a049b62a0"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "22b3f4cd1835e517741dfddccfa07fa4" +
-                                "661b74cf"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "43dd0163cdb48f9fe3212bf61b201976" +
-                                "067f342bb879ad976d8242acc188ab59" +
-                                "cabfe307"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "462401724b5ce6588d5a54aae5375513" +
-                                "a075cfcdf5042112aa29685c912fc205" +
-                                "6543"},
-                {"", "",
-                        "e66021d5eb8e4f4066d4adb9c33560e4" +
-                                "f46e44bb3da0015c94f7088736864200",
-                        "e0eaf5284d884a0e77d31646",
-                        "169fbb2fbf389a995f6390af22228a62"},
-                {"671fdd", "4fbdc66f14",
-                        "bae8e37fc83441b16034566b7a806c46" +
-                                "bb91c3c5aedb64a6c590bc84d1a5e269",
-                        "e4b47801afc0577e34699b9e",
-                        "0eaccb93da9bb81333aee0c785b240d3" +
-                                "19719d"},
-                {"195495860f04", "6787f3ea22c127aaf195",
-                        "6545fc880c94a95198874296d5cc1fd1" +
-                                "61320b6920ce07787f86743b275d1ab3",
-                        "2f6d1f0434d8848c1177441f",
-                        "a254dad4f3f96b62b84dc40c84636a5e" +
-                                "c12020ec8c2c"},
-                {"c9882e5386fd9f92ec", "489c8fde2be2cf97e74e932d4ed87d",
-                        "d1894728b3fed1473c528b8426a58299" +
-                                "5929a1499e9ad8780c8d63d0ab4149c0",
-                        "9f572c614b4745914474e7c7",
-                        "0df9e308678244c44bc0fd3dc6628dfe" +
-                                "55ebb0b9fb2295c8c2"},
-                {"1db2316fd568378da107b52b",
-                        "0da55210cc1c1b0abde3b2f204d1e9f8" +
-                                "b06bc47f",
-                        "a44102952ef94b02b805249bac80e6f6" +
-                                "1455bfac8308a2d40d8c845117808235",
-                        "5c9e940fea2f582950a70d5a",
-                        "8dbeb9f7255bf5769dd56692404099c2" +
-                                "587f64979f21826706d497d5"},
-                {"21702de0de18baa9c9596291b08466",
-                        "f37de21c7ff901cfe8a69615a93fdf7a" +
-                                "98cad481796245709f",
-                        "9745b3d1ae06556fb6aa7890bebc18fe" +
-                                "6b3db4da3d57aa94842b9803a96e07fb",
-                        "6de71860f762ebfbd08284e4",
-                        "793576dfa5c0f88729a7ed3c2f1bffb3" +
-                                "080d28f6ebb5d3648ce97bd5ba67fd"},
-                {"b202b370ef9768ec6561c4fe6b7e7296" +
-                        "fa85",
-                        "9c2159058b1f0fe91433a5bdc20e214e" +
-                                "ab7fecef4454a10ef0657df21ac7",
-                        "b18853f68d833640e42a3c02c25b6486" +
-                                "9e146d7b233987bddfc240871d7576f7",
-                        "028ec6eb5ea7e298342a94d4",
-                        "857e16a64915a787637687db4a951963" +
-                                "5cdd454fc2a154fea91f8363a39fec7d" +
-                                "0a49"},
-                {"ced532ce4159b035277d4dfbb7db6296" +
-                        "8b13cd4eec",
-                        "734320ccc9d9bbbb19cb81b2af4ecbc3" +
-                                "e72834321f7aa0f70b7282b4f33df23f" +
-                                "167541",
-                        "3c535de192eaed3822a2fbbe2ca9dfc8" +
-                                "8255e14a661b8aa82cc54236093bbc23",
-                        "688089e55540db1872504e1c",
-                        "626660c26ea6612fb17ad91e8e767639" +
-                                "edd6c9faee9d6c7029675b89eaf4ba1d" +
-                                "ed1a286594"}
-        };
+        for (String[] test : TESTS_KAT_256) {
+            byte[] plaintext = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] expected = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
+            byte[] ciphertext = new AESGCMSIV(key).encrypt(nonce, plaintext, aad);
             Assert.assertArrayEquals(expected, ciphertext);
         }
     }
 
     @Test
-    public void katDecrypt256() {
-        String[][] tests = {
-                {"", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07f5f4169bbf55a8400cd47ea6fd400f"},
-                {"0100000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2ef328e5c71c83b843122130f7364b7" +
-                                "61e0b97427e3df28"},
-                {"010000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "9aab2aeb3faa0a34aea8e2b18ca50da9" +
-                                "ae6559e48fd10f6e5c9ca17e"},
-                {"01000000000000000000000000000000", "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "85a01b63025ba19b7fd3ddfc033b3e76" +
-                                "c9eac6fa700942702e90862383c6c366"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "4a6a9db4c8c6549201b9edb53006cba8" +
-                                "21ec9cf850948a7c86c68ac7539d027f" +
-                                "e819e63abcd020b006a976397632eb5d"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c00d121893a9fa603f48ccc1ca3c57ce" +
-                                "7499245ea0046db16c53c7c66fe717e3" +
-                                "9cf6c748837b61f6ee3adcee17534ed5" +
-                                "790bc96880a99ba804bd12c0e6a22cc4"},
-                {"01000000000000000000000000000000" +
-                        "02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c2d5160a1f8683834910acdafc41fbb1" +
-                                "632d4a353e8b905ec9a5499ac34f96c7" +
-                                "e1049eb080883891a4db8caaa1f99dd0" +
-                                "04d80487540735234e3744512c6f90ce" +
-                                "112864c269fc0d9d88c61fa47e39aa08"},
-                {"0200000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "1de22967237a813291213f267e3b452f" +
-                                "02d01ae33e4ec854"},
-                {"020000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "163d6f9cc1b346cd453a2e4cc1a4a19a" +
-                                "e800941ccdc57cc8413c277f"},
-                {"02000000000000000000000000000000", "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c91545823cc24f17dbb0e9e807d5ec17" +
-                                "b292d28ff61189e8e49f3875ef91aff7"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "07dad364bfc2b9da89116d7bef6daaaf" +
-                                "6f255510aa654f920ac81b94e8bad365" +
-                                "aea1bad12702e1965604374aab96dbbc"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "c67a1f0f567a5198aa1fcc8e3f213143" +
-                                "36f7f51ca8b1af61feac35a86416fa47" +
-                                "fbca3b5f749cdf564527f2314f42fe25" +
-                                "03332742b228c647173616cfd44c54eb"},
-                {"02000000000000000000000000000000" +
-                        "03000000000000000000000000000000" +
-                        "04000000000000000000000000000000" +
-                        "05000000000000000000000000000000",
-                        "01",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "67fd45e126bfb9a79930c43aad2d3696" +
-                                "7d3f0e4d217c1e551f59727870beefc9" +
-                                "8cb933a8fce9de887b1e40799988db1f" +
-                                "c3f91880ed405b2dd298318858467c89" +
-                                "5bde0285037c5de81e5b570a049b62a0"},
-                {"02000000", "010000000000000000000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "22b3f4cd1835e517741dfddccfa07fa4" +
-                                "661b74cf"},
-                {"03000000000000000000000000000000" +
-                        "04000000",
-                        "01000000000000000000000000000000" +
-                                "0200",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "43dd0163cdb48f9fe3212bf61b201976" +
-                                "067f342bb879ad976d8242acc188ab59" +
-                                "cabfe307"},
-                {"03000000000000000000000000000000" +
-                        "0400",
-                        "01000000000000000000000000000000" +
-                                "02000000",
-                        "01000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "030000000000000000000000",
-                        "462401724b5ce6588d5a54aae5375513" +
-                                "a075cfcdf5042112aa29685c912fc205" +
-                                "6543"},
-                {"", "",
-                        "e66021d5eb8e4f4066d4adb9c33560e4" +
-                                "f46e44bb3da0015c94f7088736864200",
-                        "e0eaf5284d884a0e77d31646",
-                        "169fbb2fbf389a995f6390af22228a62"},
-                {"671fdd", "4fbdc66f14",
-                        "bae8e37fc83441b16034566b7a806c46" +
-                                "bb91c3c5aedb64a6c590bc84d1a5e269",
-                        "e4b47801afc0577e34699b9e",
-                        "0eaccb93da9bb81333aee0c785b240d3" +
-                                "19719d"},
-                {"195495860f04", "6787f3ea22c127aaf195",
-                        "6545fc880c94a95198874296d5cc1fd1" +
-                                "61320b6920ce07787f86743b275d1ab3",
-                        "2f6d1f0434d8848c1177441f",
-                        "a254dad4f3f96b62b84dc40c84636a5e" +
-                                "c12020ec8c2c"},
-                {"c9882e5386fd9f92ec", "489c8fde2be2cf97e74e932d4ed87d",
-                        "d1894728b3fed1473c528b8426a58299" +
-                                "5929a1499e9ad8780c8d63d0ab4149c0",
-                        "9f572c614b4745914474e7c7",
-                        "0df9e308678244c44bc0fd3dc6628dfe" +
-                                "55ebb0b9fb2295c8c2"},
-                {"1db2316fd568378da107b52b",
-                        "0da55210cc1c1b0abde3b2f204d1e9f8" +
-                                "b06bc47f",
-                        "a44102952ef94b02b805249bac80e6f6" +
-                                "1455bfac8308a2d40d8c845117808235",
-                        "5c9e940fea2f582950a70d5a",
-                        "8dbeb9f7255bf5769dd56692404099c2" +
-                                "587f64979f21826706d497d5"},
-                {"21702de0de18baa9c9596291b08466",
-                        "f37de21c7ff901cfe8a69615a93fdf7a" +
-                                "98cad481796245709f",
-                        "9745b3d1ae06556fb6aa7890bebc18fe" +
-                                "6b3db4da3d57aa94842b9803a96e07fb",
-                        "6de71860f762ebfbd08284e4",
-                        "793576dfa5c0f88729a7ed3c2f1bffb3" +
-                                "080d28f6ebb5d3648ce97bd5ba67fd"},
-                {"b202b370ef9768ec6561c4fe6b7e7296" +
-                        "fa85",
-                        "9c2159058b1f0fe91433a5bdc20e214e" +
-                                "ab7fecef4454a10ef0657df21ac7",
-                        "b18853f68d833640e42a3c02c25b6486" +
-                                "9e146d7b233987bddfc240871d7576f7",
-                        "028ec6eb5ea7e298342a94d4",
-                        "857e16a64915a787637687db4a951963" +
-                                "5cdd454fc2a154fea91f8363a39fec7d" +
-                                "0a49"},
-                {"ced532ce4159b035277d4dfbb7db6296" +
-                        "8b13cd4eec",
-                        "734320ccc9d9bbbb19cb81b2af4ecbc3" +
-                                "e72834321f7aa0f70b7282b4f33df23f" +
-                                "167541",
-                        "3c535de192eaed3822a2fbbe2ca9dfc8" +
-                                "8255e14a661b8aa82cc54236093bbc23",
-                        "688089e55540db1872504e1c",
-                        "626660c26ea6612fb17ad91e8e767639" +
-                                "edd6c9faee9d6c7029675b89eaf4ba1d" +
-                                "ed1a286594"}
-        };
+    public void katDecrypt256() throws AEADBadTagException {
+        for (String[] test : TESTS_KAT_256) {
+            byte[] expected = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] ciphertext = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-            byte[] decrypttext;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            Assert.assertArrayEquals(expected, ciphertext);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                Assert.assertArrayEquals(plaintext, decrypttext);
-            } catch (AEADBadTagException e) {
-                Assert.fail("");
-            }
+            byte[] decrypttext = new AESGCMSIV(key).decrypt(nonce, ciphertext, aad);
+            Assert.assertArrayEquals(expected, decrypttext);
         }
     }
 
     @Test
     public void wrapEncrypt() {
-        String[][] tests = {
-                {"00000000000000000000000000000000" +
-                        "4db923dc793ee6497c76dcc03a98e108",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "f3f80f2cf0cb2dd9c5984fcda908456c" +
-                                "c537703b5ba70324a6793a7bf218d3ea" +
-                                "ffffffff000000000000000000000000"},
-                {"eb3640277c7ffd1303c7a542d02d3e4c" +
-                        "0000000000000000",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "18ce4f0b8cb4d0cac65fea8f79257b20" +
-                                "888e53e72299e56dffffffff00000000" +
-                                "0000000000000000"}
-        };
+        for (String[] test : TESTS_KAT_WRAP) {
+            byte[] plaintext = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] expected = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
+            byte[] ciphertext = new AESGCMSIV(key).encrypt(nonce, plaintext, aad);
             Assert.assertArrayEquals(expected, ciphertext);
         }
     }
 
     @Test
-    public void wrapDecrypt() {
-        String[][] tests = {
-                {"00000000000000000000000000000000" +
-                        "4db923dc793ee6497c76dcc03a98e108",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "f3f80f2cf0cb2dd9c5984fcda908456c" +
-                                "c537703b5ba70324a6793a7bf218d3ea" +
-                                "ffffffff000000000000000000000000"},
-                {"eb3640277c7ffd1303c7a542d02d3e4c" +
-                        "0000000000000000",
-                        "",
-                        "00000000000000000000000000000000" +
-                                "00000000000000000000000000000000",
-                        "000000000000000000000000",
-                        "18ce4f0b8cb4d0cac65fea8f79257b20" +
-                                "888e53e72299e56dffffffff00000000" +
-                                "0000000000000000"}
-        };
+    public void wrapDecrypt() throws AEADBadTagException {
+        for (String[] test : TESTS_KAT_WRAP) {
+            byte[] expected = fromHex(test[0]);
+            byte[] aad = fromHex(test[1]);
+            byte[] key = fromHex(test[2]);
+            byte[] nonce = fromHex(test[3]);
+            byte[] ciphertext = fromHex(test[4]);
 
-        for (String[] test : tests) {
-            AESGCMSIV ctx;
-            byte[] key;
-            byte[] nonce;
-            byte[] plaintext;
-            byte[] aad;
-            byte[] ciphertext;
-            byte[] decrypttext;
-            byte[] expected;
-
-            plaintext = fromHex(test[0]);
-            aad = fromHex(test[1]);
-            key = fromHex(test[2]);
-            nonce = fromHex(test[3]);
-            expected = fromHex(test[4]);
-
-            ctx = new AESGCMSIV(key);
-            ciphertext = ctx.encrypt(nonce, plaintext, aad);
-
-            Assert.assertArrayEquals(expected, ciphertext);
-
-            try {
-                decrypttext = ctx.decrypt(nonce, ciphertext, aad);
-                Assert.assertArrayEquals(plaintext, decrypttext);
-            } catch (AEADBadTagException e) {
-                Assert.fail("");
-            }
+            byte[] decrypttext = new AESGCMSIV(key).decrypt(nonce, ciphertext, aad);
+            Assert.assertArrayEquals(expected, decrypttext);
         }
     }
 }

--- a/jni/aesgcmsiv_jni.c
+++ b/jni/aesgcmsiv_jni.c
@@ -16,297 +16,76 @@
 
 #include "aesgcmsiv_jni.h"
 
+#include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 
 #include "aes_gcmsiv.h"
 
-#define AES_GCMSIV_JNI_SUCCESS           0
-#define AES_GCMSIV_JNI_ERR               1
-#define AES_GCMSIV_JNI_ERR_NULL_POINTER  2
-#define AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY 3
+static int jbyteArray_new(
+    JNIEnv *env, size_t size, jbyteArray *array, uint8_t **ptr, const char *name);
+static int jbyteArray_get(
+    JNIEnv *env, jbyteArray array, const uint8_t **ptr, size_t *size, const char *name);
+static int jbyteArray_shrink(JNIEnv *env, jbyteArray *array, size_t size, const char *name);
 
-#define JAVA_EXCEPTION                   "java/lang/Exception"
-#define JAVA_AEAD_BAD_TAG_EXCEPTION      "javax/crypto/AEADBadTagException"
-#define JAVA_ILLEGAL_ARGUMENT_EXCEPTION  "java/lang/IllegalArgumentException"
-#define JAVA_NULL_POINTER_EXCEPTION      "java/lang/NullPointerException"
-#define JAVA_OUT_OF_MEMORY_EXCEPTION     "java/lang/OutOfMemoryError"
+static inline void jni_throw_exception(JNIEnv *env, const char *name, const char *msg);
+static inline void jni_throw_nullpointer_exception(JNIEnv *env, const char *msg);
+static inline void jni_throw_outofmemory_exception(JNIEnv *env, const char *msg);
+static inline void jni_throw_aesgcmsiv_exception(JNIEnv *env, aes_gcmsiv_status_t status);
 
-static int jni_get_byte_array(JNIEnv *env, jbyteArray bytes, uint8_t **array, size_t *array_sz);
-static int jni_set_byte_array(JNIEnv *env, jbyteArray *bytes, const uint8_t *data, size_t data_sz);
-static void jni_throw_aesgcmsiv_exception(JNIEnv *env, aes_gcmsiv_status_t status);
-static void jni_throw_jni_exception(JNIEnv *env, int code);
-static int jni_get_ctx(JNIEnv *env, jobject self, struct aes_gcmsiv_ctx **ctx);
-static int jni_set_ctx(JNIEnv *env, jobject self, struct aes_gcmsiv_ctx *ctx);
-static int jni_get_ctx_jfieldID(JNIEnv *env, jobject self, jfieldID *fid);
-
-/*
- * Java class native functions
- */
-
-JNIEXPORT jbyteArray JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_encrypt(
-    JNIEnv *env, jobject self, jbyteArray jnonce, jbyteArray jplain, jbyteArray jaad)
+JNIEXPORT jlong JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_initNative(JNIEnv *env,
+                                                                         jclass cls,
+                                                                         jbyteArray key)
 {
-    jbyteArray result = NULL;
-    int res;
+    jlong result = 0;
+    aes_gcmsiv_status_t res;
     struct aes_gcmsiv_ctx *ctx = NULL;
-    uint8_t *nonce = NULL;
-    size_t nonce_sz = 0;
-    uint8_t *plain = NULL;
-    size_t plain_sz = 0;
-    uint8_t *aad = NULL;
-    size_t aad_sz = 0;
-    uint8_t *cipher = NULL;
-    size_t cipher_sz = 0;
-    size_t needed_sz;
-
-    if (NULL == self) {
-        jni_throw_jni_exception(env, AES_GCMSIV_JNI_ERR_NULL_POINTER);
-        goto cleanup;
-    }
-
-    // Get AES-GCM-SIV context
-    res = jni_get_ctx(env, self, &ctx);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    // Convert input parameters to C types
-    res = jni_get_byte_array(env, jnonce, &nonce, &nonce_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    res = jni_get_byte_array(env, jplain, &plain, &plain_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    res = jni_get_byte_array(env, jaad, &aad, &aad_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    // Get needed output size
-    res = aes_gcmsiv_encrypt_size(plain_sz, aad_sz, &needed_sz);
-    if (AES_GCMSIV_SUCCESS != res) {
-        jni_throw_aesgcmsiv_exception(env, res);
-        goto cleanup;
-    }
-
-    // Allocate resources
-    cipher_sz = needed_sz;
-    cipher = malloc(cipher_sz);
-    if (NULL == cipher) {
-        jni_throw_jni_exception(env, AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY);
-        goto cleanup;
-    }
-
-    // Perform actual encryption
-    res = aes_gcmsiv_encrypt_with_tag(ctx, nonce, nonce_sz, plain, plain_sz, aad, aad_sz, cipher,
-                                      cipher_sz, &cipher_sz);
-    if (AES_GCMSIV_SUCCESS != res) {
-        jni_throw_aesgcmsiv_exception(env, res);
-        goto cleanup;
-    }
-
-    // Make returned value
-    res = jni_set_byte_array(env, &result, cipher, cipher_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-cleanup:
-    if (NULL != nonce) {
-        (*env)->ReleaseByteArrayElements(env, jnonce, (jbyte *)nonce, JNI_ABORT);
-    }
-
-    if (NULL != plain) {
-        (*env)->ReleaseByteArrayElements(env, jplain, (jbyte *)plain, JNI_ABORT);
-    }
-
-    if (NULL != aad) {
-        (*env)->ReleaseByteArrayElements(env, jaad, (jbyte *)aad, JNI_ABORT);
-    }
-
-    if (NULL != cipher) {
-        free(cipher);
-    }
-
-    return result;
-}
-
-JNIEXPORT jbyteArray JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_decrypt(
-    JNIEnv *env, jobject self, jbyteArray jnonce, jbyteArray jcipher, jbyteArray jaad)
-{
-    jbyteArray result = NULL;
-    int res;
-    struct aes_gcmsiv_ctx *ctx = NULL;
-    uint8_t *nonce = NULL;
-    size_t nonce_sz = 0;
-    uint8_t *cipher = NULL;
-    size_t cipher_sz = 0;
-    uint8_t *aad = NULL;
-    size_t aad_sz = 0;
-    uint8_t *plain = NULL;
-    size_t plain_sz = 0;
-    size_t needed_sz;
-
-    if (NULL == self) {
-        jni_throw_jni_exception(env, AES_GCMSIV_JNI_ERR_NULL_POINTER);
-        goto cleanup;
-    }
-
-    // Get AES-GCM-SIV context
-    res = jni_get_ctx(env, self, &ctx);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    // Convert input parameters to C types
-    res = jni_get_byte_array(env, jnonce, &nonce, &nonce_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    res = jni_get_byte_array(env, jcipher, &cipher, &cipher_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    res = jni_get_byte_array(env, jaad, &aad, &aad_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    // Get needed output size
-    res = aes_gcmsiv_decrypt_size(cipher_sz, aad_sz, &needed_sz);
-    if (AES_GCMSIV_SUCCESS != res) {
-        jni_throw_aesgcmsiv_exception(env, res);
-        goto cleanup;
-    }
-
-    // Allocate resources
-    plain_sz = needed_sz;
-
-    if (needed_sz > 0) {
-        plain = malloc(plain_sz);
-        if (NULL == plain) {
-            jni_throw_jni_exception(env, AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY);
-            goto cleanup;
-        }
-    }
-
-    // Perform actual decryption
-    res = aes_gcmsiv_decrypt_and_check(ctx, nonce, nonce_sz, cipher, cipher_sz, aad, aad_sz, plain,
-                                       plain_sz, &plain_sz);
-    if (AES_GCMSIV_SUCCESS != res) {
-        jni_throw_aesgcmsiv_exception(env, res);
-        goto cleanup;
-    }
-
-    // Make returned value
-    res = jni_set_byte_array(env, &result, plain, plain_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-cleanup:
-    if (NULL != nonce) {
-        (*env)->ReleaseByteArrayElements(env, jnonce, (jbyte *)nonce, JNI_ABORT);
-    }
-
-    if (NULL != cipher) {
-        (*env)->ReleaseByteArrayElements(env, jcipher, (jbyte *)cipher, JNI_ABORT);
-    }
-
-    if (NULL != aad) {
-        (*env)->ReleaseByteArrayElements(env, jaad, (jbyte *)aad, JNI_ABORT);
-    }
-
-    if (NULL != plain) {
-        free(plain);
-    }
-
-    return result;
-}
-
-JNIEXPORT void JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_init(JNIEnv *env,
-                                                                  jobject self,
-                                                                  jbyteArray jkey)
-{
-    int res;
-    struct aes_gcmsiv_ctx *ctx = NULL;
-    uint8_t *key = NULL;
+    const uint8_t *key_ptr = NULL;
     size_t key_sz = 0;
+    ((void)cls);
 
-    if (NULL == self) {
-        jni_throw_jni_exception(env, AES_GCMSIV_JNI_ERR_NULL_POINTER);
+    // Convert input parameters to C types
+    res = jbyteArray_get(env, key, &key_ptr, &key_sz, "key");
+    if (JNI_OK != res) {
         goto cleanup;
     }
 
+    // Allocate AES-GCM-SIV context
     ctx = malloc(sizeof(*ctx));
     if (NULL == ctx) {
-        jni_throw_jni_exception(env, AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY);
+        jni_throw_outofmemory_exception(env, "ctx");
         goto cleanup;
     }
 
+    // Initialize and setup AES-GCM-SIV context
     aes_gcmsiv_init(ctx);
 
-    res = jni_get_byte_array(env, jkey, &key, &key_sz);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    res = aes_gcmsiv_set_key(ctx, key, key_sz);
+    res = aes_gcmsiv_set_key(ctx, key_ptr, key_sz);
     if (AES_GCMSIV_SUCCESS != res) {
+        aes_gcmsiv_free(ctx);
+        free(ctx);
+
         jni_throw_aesgcmsiv_exception(env, res);
         goto cleanup;
     }
 
-    res = jni_set_ctx(env, self, ctx);
-    if (0 != res) {
-        jni_throw_jni_exception(env, res);
-        goto cleanup;
-    }
-
-    ctx = NULL;
+    result = (jlong)ctx;
 cleanup:
-    if (NULL != key) {
-        (*env)->ReleaseByteArrayElements(env, jkey, (jbyte *)key, JNI_ABORT);
+    if (NULL != key_ptr) {
+        (*env)->ReleaseByteArrayElements(env, key, (jbyte *)key_ptr, JNI_ABORT);
     }
 
-    if (NULL != ctx) {
-        aes_gcmsiv_free(ctx);
-        free(ctx);
-    }
-
-    return;
+    return result;
 }
 
-JNIEXPORT void JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_free(JNIEnv *env, jobject self)
+JNIEXPORT void JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_freeNative(JNIEnv *env,
+                                                                        jclass cls,
+                                                                        jlong aesGcmSivContext)
 {
-    int res;
-    struct aes_gcmsiv_ctx *ctx;
-
-    if (NULL == self) {
-        return;
-    }
-
-    res = jni_get_ctx(env, self, &ctx);
-    if (0 != res) {
-        return;
-    }
+    struct aes_gcmsiv_ctx *ctx = (struct aes_gcmsiv_ctx *)aesGcmSivContext;
+    ((void)env);
+    ((void)cls);
 
     if (NULL == ctx) {
         return;
@@ -314,199 +93,336 @@ JNIEXPORT void JNICALL Java_com_linecorp_aesgcmsiv_AESGCMSIV_free(JNIEnv *env, j
 
     aes_gcmsiv_free(ctx);
     free(ctx);
-    ctx = NULL;
+}
 
-    res = jni_set_ctx(env, self, ctx);
-    if (0 != res) {
+JNIEXPORT jbyteArray JNICALL
+Java_com_linecorp_aesgcmsiv_AESGCMSIV_encryptNative(JNIEnv *env,
+                                                    jclass cls,
+                                                    jlong aesGcmSivContext,
+                                                    jbyteArray nonce,
+                                                    jbyteArray plaintext,
+                                                    jbyteArray additionalData)
+{
+    jbyteArray result = NULL;
+    jbyteArray ciphertext = NULL;
+    aes_gcmsiv_status_t res;
+    struct aes_gcmsiv_ctx *ctx = NULL;
+    const uint8_t *nonce_ptr = NULL;
+    size_t nonce_sz = 0;
+    const uint8_t *plain_ptr = NULL;
+    size_t plain_sz = 0;
+    const uint8_t *aad_ptr = NULL;
+    size_t aad_sz = 0;
+    uint8_t *cipher_ptr = NULL;
+    size_t cipher_sz = 0;
+    size_t write_sz = 0;
+    ((void)cls);
+
+    // Convert input parameters to C types
+    ctx = (struct aes_gcmsiv_ctx *)aesGcmSivContext;
+    if (NULL == ctx) {
+        jni_throw_nullpointer_exception(env, "aesGcmSivContext");
+        goto cleanup;
+    }
+
+    res = jbyteArray_get(env, nonce, &nonce_ptr, &nonce_sz, "nonce");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    res = jbyteArray_get(env, plaintext, &plain_ptr, &plain_sz, "plaintext");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    res = jbyteArray_get(env, additionalData, &aad_ptr, &aad_sz, "additionalData");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    // Get needed output size
+    res = aes_gcmsiv_encrypt_size(plain_sz, aad_sz, &cipher_sz);
+    if (AES_GCMSIV_SUCCESS != res) {
+        jni_throw_aesgcmsiv_exception(env, res);
+        goto cleanup;
+    }
+
+    if (cipher_sz > (size_t)INT_MAX) {
+        jni_throw_aesgcmsiv_exception(env, AES_GCMSIV_INVALID_PLAINTEXT_SIZE);
+        goto cleanup;
+    }
+
+    // Allocate resources
+    res = jbyteArray_new(env, cipher_sz, &ciphertext, &cipher_ptr, "ciphertext");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    // Perform actual encryption
+    res = aes_gcmsiv_encrypt_with_tag(ctx, nonce_ptr, nonce_sz, plain_ptr, plain_sz, aad_ptr,
+                                      aad_sz, cipher_ptr, cipher_sz, &write_sz);
+    if (AES_GCMSIV_SUCCESS != res) {
+        jni_throw_aesgcmsiv_exception(env, res);
+        goto cleanup;
+    }
+
+    (*env)->ReleaseByteArrayElements(env, ciphertext, (jbyte *)cipher_ptr, 0);
+    cipher_ptr = NULL;
+
+    // Check if we actually wrote as many bytes as announced
+    if (write_sz < cipher_sz) {
+        res = jbyteArray_shrink(env, &ciphertext, write_sz, "ciphertext");
+        if (JNI_OK != res) {
+            goto cleanup;
+        }
+    }
+
+    result = ciphertext;
+    ciphertext = NULL;
+cleanup:
+    if (NULL != nonce_ptr) {
+        (*env)->ReleaseByteArrayElements(env, nonce, (jbyte *)nonce_ptr, JNI_ABORT);
+    }
+    if (NULL != plain_ptr) {
+        (*env)->ReleaseByteArrayElements(env, plaintext, (jbyte *)plain_ptr, JNI_ABORT);
+    }
+    if (NULL != aad_ptr) {
+        (*env)->ReleaseByteArrayElements(env, additionalData, (jbyte *)aad_ptr, JNI_ABORT);
+    }
+    if (NULL != cipher_ptr) {
+        (*env)->ReleaseByteArrayElements(env, ciphertext, (jbyte *)cipher_ptr, JNI_ABORT);
+    }
+
+    return result;
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_linecorp_aesgcmsiv_AESGCMSIV_decryptNative(JNIEnv *env,
+                                                    jclass cls,
+                                                    jlong aesGcmSivContext,
+                                                    jbyteArray nonce,
+                                                    jbyteArray ciphertext,
+                                                    jbyteArray additionalData)
+{
+    jbyteArray result = NULL;
+    jbyteArray plaintext = NULL;
+    aes_gcmsiv_status_t res;
+    struct aes_gcmsiv_ctx *ctx = NULL;
+    const uint8_t *nonce_ptr = NULL;
+    size_t nonce_sz = 0;
+    const uint8_t *cipher_ptr = NULL;
+    size_t cipher_sz = 0;
+    const uint8_t *aad_ptr = NULL;
+    size_t aad_sz = 0;
+    uint8_t *plain_ptr = NULL;
+    size_t plain_sz = 0;
+    size_t write_sz = 0;
+    ((void)cls);
+
+    // Convert input parameters to C types
+    ctx = (struct aes_gcmsiv_ctx *)aesGcmSivContext;
+    if (NULL == ctx) {
+        jni_throw_nullpointer_exception(env, "aesGcmSivContext");
+        goto cleanup;
+    }
+
+    res = jbyteArray_get(env, nonce, &nonce_ptr, &nonce_sz, "nonce");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    res = jbyteArray_get(env, ciphertext, &cipher_ptr, &cipher_sz, "ciphertext");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    res = jbyteArray_get(env, additionalData, &aad_ptr, &aad_sz, "additionalData");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    // Get needed output size
+    res = aes_gcmsiv_decrypt_size(cipher_sz, aad_sz, &plain_sz);
+    if (AES_GCMSIV_SUCCESS != res) {
+        jni_throw_aesgcmsiv_exception(env, res);
+        goto cleanup;
+    }
+
+    if (plain_sz > (size_t)INT_MAX) {
+        jni_throw_aesgcmsiv_exception(env, AES_GCMSIV_INVALID_CIPHERTEXT_SIZE);
+        goto cleanup;
+    }
+
+    // Allocate resources
+    res = jbyteArray_new(env, plain_sz, &plaintext, &plain_ptr, "plaintext");
+    if (JNI_OK != res) {
+        goto cleanup;
+    }
+
+    // Perform actual decryption
+    res = aes_gcmsiv_decrypt_and_check(ctx, nonce_ptr, nonce_sz, cipher_ptr, cipher_sz, aad_ptr,
+                                       aad_sz, plain_ptr, plain_sz, &write_sz);
+    if (AES_GCMSIV_SUCCESS != res) {
+        jni_throw_aesgcmsiv_exception(env, res);
+        goto cleanup;
+    }
+
+    (*env)->ReleaseByteArrayElements(env, plaintext, (jbyte *)plain_ptr, 0);
+    plain_ptr = NULL;
+
+    // Check if we actually wrote as many bytes as announced
+    if (write_sz < plain_sz) {
+        res = jbyteArray_shrink(env, &plaintext, write_sz, "ciphertext");
+        if (JNI_OK != res) {
+            goto cleanup;
+        }
+    }
+
+    result = plaintext;
+cleanup:
+    if (NULL != nonce_ptr) {
+        (*env)->ReleaseByteArrayElements(env, nonce, (jbyte *)nonce_ptr, JNI_ABORT);
+    }
+    if (NULL != cipher_ptr) {
+        (*env)->ReleaseByteArrayElements(env, ciphertext, (jbyte *)cipher_ptr, JNI_ABORT);
+    }
+    if (NULL != aad_ptr) {
+        (*env)->ReleaseByteArrayElements(env, additionalData, (jbyte *)aad_ptr, JNI_ABORT);
+    }
+    if (NULL != plain_ptr) {
+        (*env)->ReleaseByteArrayElements(env, plaintext, (jbyte *)plain_ptr, JNI_ABORT);
+    }
+
+    return result;
+}
+
+int jbyteArray_new(JNIEnv *env, size_t size, jbyteArray *array, uint8_t **ptr, const char *name)
+{
+    jbyteArray tmp = (*env)->NewByteArray(env, size);
+    if (NULL == tmp) {
+        jni_throw_outofmemory_exception(env, name);
+        return JNI_ERR;
+    }
+
+    jbyte *tmp_ptr = (*env)->GetByteArrayElements(env, tmp, NULL);
+    if (NULL == tmp_ptr) {
+        jni_throw_outofmemory_exception(env, name);
+        return JNI_ERR;
+    }
+
+    *array = tmp;
+    *ptr = (uint8_t *)tmp_ptr;
+
+    return JNI_OK;
+}
+
+int jbyteArray_get(
+    JNIEnv *env, jbyteArray array, const uint8_t **ptr, size_t *size, const char *name)
+{
+    if (NULL == array) {
+        *ptr = NULL;
+        *size = 0;
+
+        return JNI_OK;
+    }
+
+    size_t array_sz = (*env)->GetArrayLength(env, array);
+
+    jbyte *array_ptr = (*env)->GetByteArrayElements(env, array, NULL);
+    if (NULL == array_ptr) {
+        jni_throw_outofmemory_exception(env, name);
+        return JNI_ERR;
+    }
+
+    *ptr = (const uint8_t *)array_ptr;
+    *size = array_sz;
+
+    return JNI_OK;
+}
+
+int jbyteArray_shrink(JNIEnv *env, jbyteArray *array, size_t size, const char *name)
+{
+    int ret = JNI_ERR;
+
+    // Create new array
+    jbyteArray new_array = (*env)->NewByteArray(env, size);
+    if (NULL == new_array) {
+        jni_throw_outofmemory_exception(env, name);
+        goto cleanup;
+    }
+
+    // Get pointer to old array
+    jbyte *array_ptr = (*env)->GetByteArrayElements(env, *array, NULL);
+    if (NULL == array_ptr) {
+        jni_throw_outofmemory_exception(env, name);
+        goto cleanup;
+    }
+
+    // Copy old array to new array
+    (*env)->SetByteArrayRegion(env, new_array, 0, size, array_ptr);
+    if ((*env)->ExceptionCheck(env)) {
+        goto cleanup;
+    }
+
+    // Release old array and assign new one
+    (*env)->ReleaseByteArrayElements(env, *array, array_ptr, JNI_ABORT);
+    *array = new_array;
+    new_array = NULL;
+
+    ret = JNI_OK;
+cleanup:
+    if (NULL != new_array) {
+        (*env)->DeleteLocalRef(env, new_array);
+    }
+
+    return ret;
+}
+
+void jni_throw_exception(JNIEnv *env, const char *name, const char *msg)
+{
+    // Check for pending exceptions
+    if ((*env)->ExceptionCheck(env)) {
         return;
     }
+
+    // Find class, if not found, an exception is raised
+    jclass cls = (*env)->FindClass(env, name);
+    if (NULL == cls) {
+        return;
+    }
+
+    // Throw exception
+    (*env)->ThrowNew(env, cls, msg);
 }
 
-/*
- * JNI utility functions
- */
-
-int jni_get_byte_array(JNIEnv *env, jbyteArray bytes, uint8_t **array, size_t *array_sz)
+void jni_throw_nullpointer_exception(JNIEnv *env, const char *msg)
 {
-    int ret = AES_GCMSIV_JNI_ERR;
-    jbyte *tmp = NULL;
-
-    *array = NULL;
-    *array_sz = 0;
-
-    if (NULL == bytes) {
-        ret = AES_GCMSIV_JNI_SUCCESS;
-        goto cleanup;
-    }
-
-    tmp = (*env)->GetByteArrayElements(env, bytes, NULL);
-    if ((*env)->ExceptionCheck(env)) {
-        (*env)->ExceptionClear(env);
-        ret = AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY;
-        goto cleanup;
-    }
-
-    *array = (uint8_t *)tmp;
-    *array_sz = (*env)->GetArrayLength(env, bytes);
-    tmp = NULL;
-
-    ret = AES_GCMSIV_JNI_SUCCESS;
-cleanup:
-    if (NULL != tmp) {
-        (*env)->ReleaseByteArrayElements(env, bytes, (jbyte *)tmp, JNI_ABORT);
-    }
-
-    return ret;
+    jni_throw_exception(env, "java/lang/NullPointerException", msg);
 }
 
-int jni_set_byte_array(JNIEnv *env, jbyteArray *bytes, const uint8_t *data, size_t data_sz)
+void jni_throw_outofmemory_exception(JNIEnv *env, const char *msg)
 {
-    int ret = AES_GCMSIV_JNI_ERR;
-    jbyteArray tmp = NULL;
-
-    tmp = (*env)->NewByteArray(env, data_sz);
-    if ((*env)->ExceptionCheck(env)) {
-        (*env)->ExceptionClear(env);
-        ret = AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY;
-        goto cleanup;
-    }
-
-    if (data_sz > 0) {
-        (*env)->SetByteArrayRegion(env, tmp, 0, data_sz, (jbyte *)data);
-    }
-
-    *bytes = tmp;
-    tmp = NULL;
-
-    ret = AES_GCMSIV_JNI_SUCCESS;
-cleanup:
-    if (NULL != tmp) {
-        (*env)->DeleteLocalRef(env, tmp);
-    }
-
-    return ret;
+    jni_throw_exception(env, "java/lang/OutOfMemoryError", msg);
 }
 
 void jni_throw_aesgcmsiv_exception(JNIEnv *env, aes_gcmsiv_status_t status)
 {
-    const char *name = NULL;
-    const char *msg = "";
-    jclass cls = NULL;
+    const char *msg = aes_gcmsiv_get_status_code_msg(status);
 
     switch (status) {
     case AES_GCMSIV_OUT_OF_MEMORY:
-        name = JAVA_OUT_OF_MEMORY_EXCEPTION;
-        break;
-    case AES_GCMSIV_INVALID_TAG:
-        name = JAVA_AEAD_BAD_TAG_EXCEPTION;
-        break;
+        return jni_throw_exception(env, "java/lang/OutOfMemoryError", msg);
+    case AES_GCMSIV_UPDATE_OUTPUT_SIZE:
     case AES_GCMSIV_INVALID_PARAMETERS:
     case AES_GCMSIV_INVALID_KEY_SIZE:
     case AES_GCMSIV_INVALID_NONCE_SIZE:
     case AES_GCMSIV_INVALID_PLAINTEXT_SIZE:
     case AES_GCMSIV_INVALID_AAD_SIZE:
     case AES_GCMSIV_INVALID_CIPHERTEXT_SIZE:
-        name = JAVA_ILLEGAL_ARGUMENT_EXCEPTION;
-        break;
+        return jni_throw_exception(env, "java/lang/IllegalArgumentException", msg);
+    case AES_GCMSIV_INVALID_TAG:
+        return jni_throw_exception(env, "javax/crypto/AEADBadTagException", msg);
     default:
-        name = JAVA_EXCEPTION;
-        break;
+        return jni_throw_exception(env, "java/lang/Exception", msg);
     }
-
-    msg = aes_gcmsiv_get_status_code_msg(status);
-
-    cls = (*env)->FindClass(env, name);
-    if (!(*env)->ExceptionCheck(env)) {
-        (*env)->ThrowNew(env, cls, msg);
-    }
-}
-
-void jni_throw_jni_exception(JNIEnv *env, int code)
-{
-    const char *name = NULL;
-    const char *msg = "";
-    jclass cls = NULL;
-
-    switch (code) {
-    case AES_GCMSIV_JNI_ERR_NULL_POINTER:
-        name = JAVA_NULL_POINTER_EXCEPTION;
-        msg = "null";
-        break;
-    case AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY:
-        name = JAVA_OUT_OF_MEMORY_EXCEPTION;
-        msg = "Cannot allocate enough memory";
-        break;
-    default:
-        name = JAVA_EXCEPTION;
-        msg = "";
-        break;
-    }
-
-    cls = (*env)->FindClass(env, name);
-    if (!(*env)->ExceptionCheck(env)) {
-        (*env)->ThrowNew(env, cls, msg);
-    }
-}
-
-int jni_get_ctx(JNIEnv *env, jobject self, struct aes_gcmsiv_ctx **ctx)
-{
-    int ret = AES_GCMSIV_JNI_ERR;
-    int res;
-    jfieldID fid = NULL;
-
-    res = jni_get_ctx_jfieldID(env, self, &fid);
-    if (0 != res) {
-        ret = res;
-        goto cleanup;
-    }
-
-    *ctx = (struct aes_gcmsiv_ctx *)(*env)->GetLongField(env, self, fid);
-
-    ret = AES_GCMSIV_JNI_SUCCESS;
-cleanup:
-    return ret;
-}
-
-int jni_set_ctx(JNIEnv *env, jobject self, struct aes_gcmsiv_ctx *ctx)
-{
-    int ret = AES_GCMSIV_JNI_ERR;
-    int res;
-    jfieldID fid = NULL;
-
-    res = jni_get_ctx_jfieldID(env, self, &fid);
-    if (0 != res) {
-        ret = res;
-        goto cleanup;
-    }
-
-    (*env)->SetLongField(env, self, fid, (jlong)ctx);
-
-    ret = AES_GCMSIV_JNI_SUCCESS;
-cleanup:
-    return ret;
-}
-
-int jni_get_ctx_jfieldID(JNIEnv *env, jobject self, jfieldID *fid)
-{
-    int ret = AES_GCMSIV_JNI_ERR;
-    static jfieldID ctx_id = NULL;
-    jclass cls;
-
-    if (NULL == ctx_id) {
-        cls = (*env)->GetObjectClass(env, self);
-
-        ctx_id = (*env)->GetFieldID(env, cls, "aes_gcmsiv_ctx", "J");
-        if ((*env)->ExceptionCheck(env)) {
-            ctx_id = NULL;
-            (*env)->ExceptionClear(env);
-            ret = AES_GCMSIV_JNI_ERR_OUT_OF_MEMORY;
-            goto cleanup;
-        }
-    }
-
-    *fid = ctx_id;
-
-    ret = AES_GCMSIV_JNI_SUCCESS;
-cleanup:
-    return ret;
 }


### PR DESCRIPTION
This PR simplifies the JNI bindings by improving native context handling and exception management.

1. Changes to JNI bindings:
    - native functions now take the context pointer directly as a parameter.
        - prevents manipulating the object field in the bindings
    - encryption and decryption now write directly to Java arrays.
        - prevents allocating a buffer and then copying it to the returned array
2. Refactoring of the JNI exception handling:
    - add helper functions for `OutOfMemoryError`, `NullPointerException`, and AES-GCM-SIV exceptions.
    - those helper functions all use `jni_throw_exception`, which performs checks for pending exceptions.
        - prevents accidental exception shadowing
    - `static` functions throw exceptions appropriately when their return code indicates a failure.
        - prevents callers from having to determine whether an exception should be raised.
3. Changes to the Java / Android libraries:
    - update how the native context is used to reflect the JNI changes
    - update the unit tests:
        - add tests for the `finalize` method, especially regarding multiple `finalize` calls
        - make KAT vectors global, so the same arrays are reused for both encryption and decryption
        - remove unnecessary asserts (especially `Assert.assertTrue(true)`).