### PR TITLE
Allow specifying temporary directory in Java library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add the `com.linecorp.aesgcmsiv.tmpdir` JVM property to configure where the Java library extracts its native JNI library
+
 ## 1.5.0
 
 - Raise CMake minimum required version to `3.14`

--- a/java/README.md
+++ b/java/README.md
@@ -92,7 +92,9 @@ Then, the `os.name` property is checked with a `startWith` to see which library 
 If the file cannot be found in the JAR archive, then an exception is raised.
 
 The native JNI library is extracted from the JAR and copied in a temporary folder `${TEMP_DIR}/aesgcmsiv_jni-${RANDOM}`, where it can be loaded by the JVM.
-The `TEMP_DIR` value is taken from the JVM property `java.io.tmpdir`, and should have permissions to create directory and files.
+The `TEMP_DIR` value is taken from the JVM property `com.linecorp.aesgcmsiv.tmpdir` when it is set to a non-blank value, and otherwise falls back to `java.io.tmpdir`.
+For example, use `-Dcom.linecorp.aesgcmsiv.tmpdir=/var/lib/aesgcmsiv/tmp` to configure a library-specific location.
+The directory must already exist, must allow the application to create directories and files, and must be on a filesystem that permits executable mappings of shared libraries.
 The `RANDOM` value is a random number prefix used to avoid collision of names as much as possible.
 
 The temporary JNI library copied on the disk is marked as `deleteOnExit`, so it should be deleted automatically by the JVM when it stops.

--- a/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/ResourceLoader.java
+++ b/java/aesgcmsiv/src/main/java/com/linecorp/aesgcmsiv/ResourceLoader.java
@@ -21,10 +21,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 final class ResourceLoader {
     private static final String JNI_BASE_DIR = "jni";
+    private static final String TMP_DIR_PROPERTY = "com.linecorp.aesgcmsiv.tmpdir";
     private static final String TMP_DIR_PREFIX = "aesgcmsiv_jni-";
     private static volatile File libFile;
 
@@ -47,7 +50,7 @@ final class ResourceLoader {
         InputStream libStream = getResourceAsStream(libPath);
 
         // Create temporary directory
-        File tmpDir = Files.createTempDirectory(TMP_DIR_PREFIX).toFile();
+        File tmpDir = Files.createTempDirectory(getTmpDirectory(), TMP_DIR_PREFIX).toFile();
         tmpDir.deleteOnExit();
 
         // Copy library to temporary directory
@@ -57,6 +60,15 @@ final class ResourceLoader {
         Files.copy(libStream, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         return tmpFile;
+    }
+
+    static Path getTmpDirectory() {
+        String tmpDir = System.getProperty(TMP_DIR_PROPERTY);
+        if (tmpDir == null || tmpDir.trim().isEmpty()) {
+            tmpDir = System.getProperty("java.io.tmpdir");
+        }
+
+        return Paths.get(tmpDir);
     }
 
     private static String getLibNameByOs(String lib) throws RuntimeException {

--- a/java/aesgcmsiv/src/test/java/com/linecorp/aesgcmsiv/ResourceLoaderTest.java
+++ b/java/aesgcmsiv/src/test/java/com/linecorp/aesgcmsiv/ResourceLoaderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.aesgcmsiv;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+public class ResourceLoaderTest {
+    private static final String TMP_DIR_PROPERTY = "com.linecorp.aesgcmsiv.tmpdir";
+
+    private String originalTmpDirectory;
+
+    @Before
+    public void backupEnvironment() {
+        originalTmpDirectory = System.getProperty(TMP_DIR_PROPERTY);
+    }
+
+    @After
+    public void restoreEnvironment() {
+        if (originalTmpDirectory == null) {
+            System.clearProperty(TMP_DIR_PROPERTY);
+        } else {
+            System.setProperty(TMP_DIR_PROPERTY, originalTmpDirectory);
+        }
+    }
+
+    @Test
+    public void customTmpDirectoryTakesPrecedence() {
+        System.setProperty(TMP_DIR_PROPERTY, "/custom/aesgcmsiv/tmp");
+
+        Assert.assertEquals(
+                Paths.get("/custom/aesgcmsiv/tmp"),
+                ResourceLoader.getTmpDirectory());
+    }
+
+    @Test
+    public void javaTmpDirectoryIsTheDefault() {
+        System.clearProperty(TMP_DIR_PROPERTY);
+
+        Assert.assertEquals(
+                Paths.get(System.getProperty("java.io.tmpdir")),
+                ResourceLoader.getTmpDirectory());
+    }
+
+    @Test
+    public void blankCustomTmpDirectoryUsesTheDefault() {
+        System.setProperty(TMP_DIR_PROPERTY, "   ");
+
+        Assert.assertEquals(
+                Paths.get(System.getProperty("java.io.tmpdir")),
+                ResourceLoader.getTmpDirectory());
+    }
+}


### PR DESCRIPTION
This PR allows the Java library to specify a custom temporary directory. This is useful in cases like Rocky Linux 9, which mounts `/tmp` as `noexec` by default, so it's not possible to load the library without remounting `/tmp` or moving `java.io.tmpdir`.